### PR TITLE
docs: enhance webhook signature verification details across multiple guides

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -404,7 +404,7 @@ Set up webhooks to receive real-time updates:
 
 ### Webhook Payload
 
-Webhook signatures use HMAC-SHA256. Verify against the raw request body, not re-serialized JSON.
+Webhook signatures use HMAC-SHA256 over the **exact raw request body**. Do not re-serialize parsed JSON (key ordering differs). The `X-Paycrest-Signature` header is a **hex string** — compare using timing-safe equality on the **UTF-8 bytes of the hex strings** (see the [Sender API integration guide](/implementation-guides/sender-api-integration#verify-webhook-signatures)). If verification fails with the correct API secret, check the guide note on **legacy trailing newline** on the body.
 
 ```json
 {

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -404,7 +404,7 @@ Set up webhooks to receive real-time updates:
 
 ### Webhook Payload
 
-Webhook signatures use HMAC-SHA256 over the **exact raw request body**. Do not re-serialize parsed JSON (key ordering differs). The `X-Paycrest-Signature` header is a **hex string** — compare using timing-safe equality on the **UTF-8 bytes of the hex strings** (see the [Sender API integration guide](/implementation-guides/sender-api-integration#verify-webhook-signatures)). If verification fails with the correct API secret, check the guide note on **legacy trailing newline** on the body.
+Webhook signatures use HMAC-SHA256 over the **exact raw request body**. Do not re-serialize parsed JSON (key ordering differs). The `X-Paycrest-Signature` header is a **hex string** — compare using timing-safe equality on the **UTF-8 bytes of the hex strings** (see the [Sender API integration guide](/implementation-guides/sender-api-integration#verify-webhook-signatures)).
 
 ```json
 {

--- a/concepts/transaction-lifecycle.mdx
+++ b/concepts/transaction-lifecycle.mdx
@@ -224,7 +224,9 @@ The v2 payload adds a `direction` field and uses polymorphic `source`/`destinati
 
 ## Webhook Verification
 
-Verify the authenticity of webhook payloads using your API Secret to compute an HMAC-SHA256 signature and compare it against the `X-Paycrest-Signature` header. Always verify against the **raw request body bytes** — do not parse and re-serialize the JSON, as key ordering may differ:
+Verify the authenticity of webhook payloads using your API Secret to compute an HMAC-SHA256 signature and compare it against the `X-Paycrest-Signature` header. Always verify against the **raw request body bytes** — do not parse and re-serialize the JSON, as key ordering may differ.
+
+The `X-Paycrest-Signature` value is a **hex string**. Use **timing-safe** comparison on the **UTF-8 bytes** of the hex strings (`Buffer.from(hex, 'utf8')`), not `Buffer.from(hex, 'hex')`. Trim and lowercase the header first. If verification fails with the correct secret, see the Sender API guide note on **legacy trailing newline** on the request body.
 
 <Tabs>
   <Tab title="JavaScript">
@@ -232,14 +234,18 @@ Verify the authenticity of webhook payloads using your API Secret to compute an 
 const crypto = require('crypto');
 
 function verifyWebhook(rawBody, signature, secret) {
-  const computed = crypto
-    .createHmac('sha256', secret)
-    .update(rawBody) // rawBody is the raw request body Buffer/string
-    .digest('hex');
-  return crypto.timingSafeEqual(
-    Buffer.from(computed),
-    Buffer.from(signature)
-  );
+  const sig = (signature && String(signature).trim().toLowerCase()) || '';
+  const key = String(secret || '').trim();
+  if (!sig || !key) return false;
+
+  const bodyBuf = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8');
+  const computed = crypto.createHmac('sha256', key).update(bodyBuf).digest('hex').toLowerCase();
+  if (computed.length !== sig.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(computed, 'utf8'), Buffer.from(sig, 'utf8'));
+  } catch {
+    return false;
+  }
 }
 ```
   </Tab>
@@ -250,12 +256,14 @@ import hashlib
 
 def verify_webhook(raw_body, signature, secret):
     # raw_body is request.data (raw bytes)
+    sig = (signature or "").strip().lower()
+    body = raw_body if isinstance(raw_body, bytes) else raw_body.encode()
     computed = hmac.new(
-        secret.encode(),
-        raw_body if isinstance(raw_body, bytes) else raw_body.encode(),
-        hashlib.sha256
-    ).hexdigest()
-    return hmac.compare_digest(computed, signature)
+        secret.strip().encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest().lower()
+    return hmac.compare_digest(computed, sig)
 ```
   </Tab>
   <Tab title="Go">
@@ -264,13 +272,15 @@ import (
     "crypto/hmac"
     "crypto/sha256"
     "encoding/hex"
+    "strings"
 )
 
 func verifyWebhook(payload []byte, signature, secret string) bool {
-    mac := hmac.New(sha256.New, []byte(secret))
+    mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
     mac.Write(payload)
     computed := hex.EncodeToString(mac.Sum(nil))
-    return hmac.Equal([]byte(computed), []byte(signature))
+    sig := strings.ToLower(strings.TrimSpace(signature))
+    return hmac.Equal([]byte(computed), []byte(sig))
 }
 ```
   </Tab>

--- a/concepts/transaction-lifecycle.mdx
+++ b/concepts/transaction-lifecycle.mdx
@@ -226,7 +226,7 @@ The v2 payload adds a `direction` field and uses polymorphic `source`/`destinati
 
 Verify the authenticity of webhook payloads using your API Secret to compute an HMAC-SHA256 signature and compare it against the `X-Paycrest-Signature` header. Always verify against the **raw request body bytes** — do not parse and re-serialize the JSON, as key ordering may differ.
 
-The `X-Paycrest-Signature` value is a **hex string**. Use **timing-safe** comparison on the **UTF-8 bytes** of the hex strings (`Buffer.from(hex, 'utf8')`), not `Buffer.from(hex, 'hex')`. Trim and lowercase the header first. If verification fails with the correct secret, see the Sender API guide note on **legacy trailing newline** on the request body.
+The `X-Paycrest-Signature` value is a **hex string**. Use **timing-safe** comparison on the **UTF-8 bytes** of the hex strings (`Buffer.from(hex, 'utf8')`), not `Buffer.from(hex, 'hex')`. Trim and lowercase the header first.
 
 <Tabs>
   <Tab title="JavaScript">

--- a/concepts/use-cases.mdx
+++ b/concepts/use-cases.mdx
@@ -251,25 +251,30 @@ const express = require('express');
 const crypto = require('crypto');
 const app = express();
 
-app.use(express.json());
-
-// Webhook signature verification
-function verifySignature(rawBody, signature, secret) {
-  const hash = crypto.createHmac('sha256', secret)
-    .update(rawBody) // rawBody is the raw request body string/Buffer
-    .digest('hex');
-  return signature === hash;
+// Use raw body for this route only — do not use express.json() before webhook verification
+function verifyPaycrestSignature(rawBody, signature, secret) {
+  const sig = (signature && String(signature).trim().toLowerCase()) || '';
+  const key = String(secret || '').trim();
+  if (!sig || !key) return false;
+  const bodyBuf = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8');
+  const computed = crypto.createHmac('sha256', key).update(bodyBuf).digest('hex').toLowerCase();
+  if (computed.length !== sig.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(computed, 'utf8'), Buffer.from(sig, 'utf8'));
+  } catch {
+    return false;
+  }
 }
 
-// Webhook endpoint for order updates
-app.post('/webhooks/paycrest', async (req, res) => {
+// Webhook endpoint for order updates (raw JSON bytes for HMAC)
+app.post('/webhooks/paycrest', express.raw({ type: 'application/json' }), async (req, res) => {
   const signature = req.get('X-Paycrest-Signature');
-  
-  if (!verifySignature(req.body, signature, process.env.WEBHOOK_SECRET)) {
+
+  if (!verifyPaycrestSignature(req.body, signature, process.env.WEBHOOK_SECRET)) {
     return res.status(401).send('Invalid signature');
   }
-  
-  const { event, orderId, status, data } = req.body;
+
+  const { event, orderId, status, data } = JSON.parse(req.body);
   
   try {
     // Update order status in database

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -379,10 +379,6 @@ Verify the `X-Paycrest-Signature` header using HMAC-SHA256 with your API Secret:
 
 The header value is a **hex string** (64 characters for SHA-256). Compare it to your computed hex using **timing-safe equality on the UTF-8 bytes of those strings** (do not `Buffer.from(hex, 'hex')` for the header — that compares raw digest bytes and does not match how the aggregator compares signatures). Normalize the header with **trim** and **lowercase** before comparing.
 
-<Note>
-  Older aggregator builds signed **`json.Marshal`** bytes but sent the body with **`json.Encoder.Encode`**, which appends a trailing newline. If verification fails with a correct secret, retry HMAC on the same body **with one trailing `\n` or `\r\n` removed**. Current aggregators send the exact JSON bytes that were signed.
-</Note>
-
 <Tabs>
   <Tab title="JavaScript">
 ```javascript

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -377,17 +377,30 @@ Configure your webhook URL in the [Sender Dashboard](https://app.paycrest.io). W
 
 Verify the `X-Paycrest-Signature` header using HMAC-SHA256 with your API Secret:
 
+The header value is a **hex string** (64 characters for SHA-256). Compare it to your computed hex using **timing-safe equality on the UTF-8 bytes of those strings** (do not `Buffer.from(hex, 'hex')` for the header — that compares raw digest bytes and does not match how the aggregator compares signatures). Normalize the header with **trim** and **lowercase** before comparing.
+
+<Note>
+  Older aggregator builds signed **`json.Marshal`** bytes but sent the body with **`json.Encoder.Encode`**, which appends a trailing newline. If verification fails with a correct secret, retry HMAC on the same body **with one trailing `\n` or `\r\n` removed**. Current aggregators send the exact JSON bytes that were signed.
+</Note>
+
 <Tabs>
   <Tab title="JavaScript">
 ```javascript
 const crypto = require('crypto');
 
 function verifyWebhook(rawBody, signature, secret) {
-  const computed = crypto
-    .createHmac('sha256', secret)
-    .update(rawBody)
-    .digest('hex');
-  return crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(signature));
+  const sig = (signature && String(signature).trim().toLowerCase()) || '';
+  const key = String(secret || '').trim();
+  if (!sig || !key) return false;
+
+  const bodyBuf = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8');
+  const computed = crypto.createHmac('sha256', key).update(bodyBuf).digest('hex').toLowerCase();
+  if (computed.length !== sig.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(computed, 'utf8'), Buffer.from(sig, 'utf8'));
+  } catch {
+    return false;
+  }
 }
 
 app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
@@ -406,8 +419,9 @@ app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
 import hmac, hashlib
 
 def verify_webhook(raw_body: bytes, signature: str, secret: str) -> bool:
-    computed = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(computed, signature)
+    sig = (signature or "").strip().lower()
+    computed = hmac.new(secret.strip().encode("utf-8"), raw_body, hashlib.sha256).hexdigest().lower()
+    return hmac.compare_digest(computed, sig)
 
 @app.route('/webhook', methods=['POST'])
 def webhook():
@@ -422,17 +436,20 @@ def webhook():
   <Tab title="Go">
 ```go
 import (
-    "crypto/hmac"
-    "crypto/sha256"
-    "encoding/hex"
-    "io"
-    "net/http"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"strings"
 )
 
 func verifyWebhook(body []byte, signature, secret string) bool {
-    mac := hmac.New(sha256.New, []byte(secret))
-    mac.Write(body)
-    return hmac.Equal([]byte(hex.EncodeToString(mac.Sum(nil))), []byte(signature))
+	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
+	mac.Write(body)
+	computed := hex.EncodeToString(mac.Sum(nil))
+	sig := strings.ToLower(strings.TrimSpace(signature))
+	return hmac.Equal([]byte(computed), []byte(sig))
 }
 
 func webhookHandler(w http.ResponseWriter, r *http.Request) {

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -86,15 +86,21 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
       const crypto = require('crypto');
       
       function verifyWebhookSignature(rawBody, signature, secret) {
-        const expectedSignature = crypto
-          .createHmac('sha256', secret)
-          .update(rawBody) // rawBody is the raw request body string/Buffer
-          .digest('hex');
-        
-        return crypto.timingSafeEqual(
-          Buffer.from(signature),
-          Buffer.from(expectedSignature)
-        );
+        const sig = (signature && String(signature).trim().toLowerCase()) || '';
+        const key = String(secret || '').trim();
+        if (!sig || !key) return false;
+
+        const bodyBuf = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8');
+        const expected = crypto.createHmac('sha256', key).update(bodyBuf).digest('hex').toLowerCase();
+        if (expected.length !== sig.length) return false;
+        try {
+          return crypto.timingSafeEqual(
+            Buffer.from(expected, 'utf8'),
+            Buffer.from(sig, 'utf8')
+          );
+        } catch {
+          return false;
+        }
       }
       ```
       </Tab>
@@ -105,13 +111,14 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
       
       def verify_webhook_signature(raw_body, signature, secret):
           # raw_body is the raw request body bytes
-          expected_signature = hmac.new(
-              secret.encode('utf-8'),
-              raw_body if isinstance(raw_body, bytes) else raw_body.encode('utf-8'),
-              hashlib.sha256
-          ).hexdigest()
-          
-          return hmac.compare_digest(signature, expected_signature)
+          sig = (signature or "").strip().lower()
+          body = raw_body if isinstance(raw_body, bytes) else raw_body.encode("utf-8")
+          expected = hmac.new(
+              secret.strip().encode("utf-8"),
+              body,
+              hashlib.sha256,
+          ).hexdigest().lower()
+          return hmac.compare_digest(expected, sig)
       ```
       </Tab>
       <Tab title="Go">
@@ -122,16 +129,16 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
           "crypto/hmac"
           "crypto/sha256"
           "encoding/hex"
-          "fmt"
+          "strings"
       )
       
       func verifyWebhookSignature(rawBody []byte, signature, secret string) bool {
           // rawBody is the raw request body bytes
-          h := hmac.New(sha256.New, []byte(secret))
+          h := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
           h.Write(rawBody)
-          expectedSignature := hex.EncodeToString(h.Sum(nil))
-          
-          return hmac.Equal([]byte(signature), []byte(expectedSignature))
+          expected := hex.EncodeToString(h.Sum(nil))
+          sig := strings.ToLower(strings.TrimSpace(signature))
+          return hmac.Equal([]byte(expected), []byte(sig))
       }
       ```
       </Tab>


### PR DESCRIPTION
- Clarified the process for verifying webhook signatures using HMAC-SHA256, emphasizing the importance of using the exact raw request body and timing-safe comparison for hex strings.
- Updated code examples in JavaScript, Python, and Go to reflect best practices for signature verification, including normalization of the signature and secret.
- Added notes regarding legacy issues with trailing newlines in webhook payloads to assist developers in troubleshooting verification failures.
- Improved documentation in the sender API integration guide and troubleshooting section to ensure consistency and clarity in webhook handling.

closes https://github.com/paycrest/aggregator/issues/782