### PR TITLE
docs/sender mcp guide

### DIFF
--- a/api-reference/general/verify-account.mdx
+++ b/api-reference/general/verify-account.mdx
@@ -18,7 +18,6 @@ For institutions with type **mobile_money**, the API **normalizes** `accountIden
 | UGX | 256 |
 | TZS | 255 |
 | GHS | 233 |
-| MWK | 265 |
 
 **KES M-Pesa example:** `0712345678`, `+254712345678`, and `254712345678` all normalize to `254712345678`.
 
@@ -36,6 +35,6 @@ Pass optional **`metadata`** on the verify request for Till/Paybill validation.
 ## Response `data`
 
 - A **real name** (e.g. `"JOHN DOE"`) — use that exact string as `accountName` on the order.
-- **`"OK"`** — account treated as valid but name lookup is unavailable for that corridor (common for some KES/GHS/UGX/MWK mobile flows). Provide your own `accountName` on the order.
+- **`"OK"`** — account treated as valid but name lookup is unavailable for that corridor (common for some KES/GHS/UGX mobile flows). Provide your own `accountName` on the order.
 
 The same checks run again when you create an order; calling verify first improves checkout UX.

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -121,7 +121,6 @@ The **aggregator node** is the coordination layer: it monitors onchain events, m
   </Card>
   <Card title="Mobile Money">
     - M-Pesa, Airtel Money, MTN Mobile Money
-    - PIX (Brazil)
     - Other mobile wallets
   </Card>
 </CardGroup>

--- a/concepts/participants.mdx
+++ b/concepts/participants.mdx
@@ -49,7 +49,7 @@ The **beneficiary** of the transaction who receives funds without interacting wi
 ### Delivery Methods
 
 - **Bank Transfer**: Direct deposit to local bank account
-- **Mobile**: Transfer to mobile wallet (M-Pesa, etc.) or mobile payment systems (UPI, PIX)
+- **Mobile**: Transfer to mobile wallet (M-Pesa, etc.) or other mobile payment systems
 - **Crypto Wallet**: Receive stablecoins in specified wallet
 
 > **Note:** Cash pickup is not supported. All off-ramps are to fiat accounts or wallets.

--- a/docs.json
+++ b/docs.json
@@ -48,6 +48,7 @@
                 "group": "Implementation Guides",
                 "pages": [
                   "implementation-guides/sender-api-integration",
+                  "implementation-guides/sender-mcp",
                   "implementation-guides/smart-contract-interaction",
                   "implementation-guides/provider-setup-guide"
                 ]

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -12,6 +12,8 @@ Both flows use the same endpoint: **`POST /v2/sender/orders`**. Direction comes 
 
 **Fastest path to production:** one authenticated create call. The API **validates** bank or mobile account details and **resolves** an acceptable rate inside that request—you are **not** required to call verify-account or the public rates URL first. The sections after [Create a payment order](#create-a-payment-order) cover what happens next (response shape, webhooks). [Optional: prefetch quotes and account names](#optional-prefetch-quotes-and-account-names) explains how to polish checkout when you want prefetching—not because it is required.
 
+Prefer Cursor / natural language? See [Sender MCP](/implementation-guides/sender-mcp).
+
 ## Flow Overview
 
 <Tabs>

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -12,7 +12,9 @@ Both flows use the same endpoint: **`POST /v2/sender/orders`**. Direction comes 
 
 **Fastest path to production:** one authenticated create call. The API **validates** bank or mobile account details and **resolves** an acceptable rate inside that request—you are **not** required to call verify-account or the public rates URL first. The sections after [Create a payment order](#create-a-payment-order) cover what happens next (response shape, webhooks). [Optional: prefetch quotes and account names](#optional-prefetch-quotes-and-account-names) explains how to polish checkout when you want prefetching—not because it is required.
 
-Prefer Cursor / natural language? See [Sender Agent Guide](/implementation-guides/sender-mcp).
+<Note>
+Prefer natural language? Create and track orders from **Claude Code**, **Cursor**, or **VS Code** with the [Sender Agent Guide](/implementation-guides/sender-mcp) (MCP).
+</Note>
 
 ## Flow Overview
 
@@ -736,3 +738,4 @@ The response includes `receiveAddress` (string) and `validUntil`. Send tokens to
 - [Supported Stablecoins](/resources/supported-stablecoins) — tokens, networks, contract addresses
 - [Supported Currencies](/resources/supported-currencies) — active fiat corridors
 - [API Reference — Sender](/api-reference/sender/initiate-payment-order-v2) — full endpoint spec
+- [Sender Agent Guide](/implementation-guides/sender-mcp) — run Paycrest from Claude Code, Cursor, or VS Code via MCP

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -12,7 +12,7 @@ Both flows use the same endpoint: **`POST /v2/sender/orders`**. Direction comes 
 
 **Fastest path to production:** one authenticated create call. The API **validates** bank or mobile account details and **resolves** an acceptable rate inside that request—you are **not** required to call verify-account or the public rates URL first. The sections after [Create a payment order](#create-a-payment-order) cover what happens next (response shape, webhooks). [Optional: prefetch quotes and account names](#optional-prefetch-quotes-and-account-names) explains how to polish checkout when you want prefetching—not because it is required.
 
-Prefer Cursor / natural language? See [Sender MCP](/implementation-guides/sender-mcp).
+Prefer Cursor / natural language? See [Sender Agent Guide](/implementation-guides/sender-mcp).
 
 ## Flow Overview
 

--- a/implementation-guides/sender-mcp.mdx
+++ b/implementation-guides/sender-mcp.mdx
@@ -1,22 +1,26 @@
 ---
 title: "Sender Agent Guide"
-description: "Install and use the Paycrest sender agent (MCP) in Cursor or VS Code to create and track payment orders with natural language."
+description: "Install the Paycrest sender agent (MCP) and connect it to Claude Code, Cursor, or VS Code to create and track payment orders with natural language."
 ---
 
-Use **Paycrest** from **Cursor** or **VS Code** through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). A small app runs on your machine, talks to the Paycrest API, and lets your AI agent create and track payment orders in plain language.
+Use **Paycrest** from **Claude Code**, **Cursor**, or **VS Code** through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). A small app runs on your machine, talks to the Paycrest API, and lets your AI agent create and track payment orders in plain language.
 
-You do **not** need Go or a local clone for normal use — only an MCP-capable editor and a sender API key.
+You do **not** need Go or a local clone for normal use — only an MCP-capable client and a sender API key.
 
 For HTTP API integration (apps and backends), see [Sender API Integration](/implementation-guides/sender-api-integration).
 
 ## Prerequisites
 
-1. **[Cursor](https://cursor.com/)** or **[VS Code](https://code.visualstudio.com/)** with GitHub Copilot Chat installed
+1. An **MCP client** — one of:
+   - **[Claude Code](https://claude.com/claude-code)**
+   - **[Cursor](https://cursor.com/)**
+   - **[VS Code](https://code.visualstudio.com/)** with GitHub Copilot Chat (**Agent** mode)
 2. A **sender API key** from the [Paycrest dashboard](https://paycrest.io) (Settings → API keys)
+3. On Windows, **Windows PowerShell** — not Git Bash — for the install one-liner
 
-## Install
+## Install the agent
 
-The installer downloads the latest release binary to a **fixed path** and can wire Cursor’s MCP config for you.
+The installer downloads the latest release binary to a **fixed path**. It configures Cursor automatically; Claude Code and VS Code are one manual step each, below.
 
 | OS | Binary path |
 |----|-------------|
@@ -41,15 +45,110 @@ curl -fsSL https://raw.githubusercontent.com/paycrest/sender-mcp/main/scripts/in
 
 1. Downloads the matching binary from [Releases](https://github.com/paycrest/sender-mcp/releases)
 2. Saves it under `~/.paycrest/` with a fixed name (no manual rename)
-3. Merges a `paycrest` entry into Cursor’s `~/.cursor/mcp.json` (unless you skip that step)
+3. Merges a `paycrest` entry into **Cursor’s** `~/.cursor/mcp.json` (unless you skip that step)
 
 <Note>
+The script does **not** configure Claude Code or VS Code — see [Connect Claude Code](#connect-claude-code) and [Connect VS Code](#connect-vs-code).
+
 Ignore the **Source code (zip/tar.gz)** links on the Releases page — those are source archives, not the MCP binary.
 </Note>
 
-## Configure Cursor (`mcp.json`)
+### Where the config lives
 
-You only need **`PAYCREST_API_KEY`**.
+All three clients run the **same binary** from the path above. Only the config file and its top-level key differ.
+
+| Client | Config | Top-level key |
+|--------|--------|---------------|
+| Claude Code | `~/.claude.json` (local / user scope), or `.mcp.json` in the repo root (project scope) — managed by `claude mcp` | `mcpServers` |
+| Cursor | `~/.cursor/mcp.json` | `mcpServers` |
+| VS Code | Command Palette → **MCP: Open User Configuration** | `servers` (plus `"type": "stdio"`) |
+
+You only ever need one environment variable: **`PAYCREST_API_KEY`**.
+
+## Connect Claude Code
+
+The installer does not touch Claude Code. Add the server with one command:
+
+<CodeGroup>
+
+```powershell Windows
+claude mcp add --env PAYCREST_API_KEY=your-sender-api-key --transport stdio --scope user paycrest -- C:/Users/YOU/.paycrest/paycrest-mcp.exe
+```
+
+```bash macOS / Linux
+claude mcp add --env PAYCREST_API_KEY=your-sender-api-key --transport stdio --scope user paycrest -- ~/.paycrest/paycrest-mcp
+```
+
+</CodeGroup>
+
+<Warning>
+Two flag-order rules, both easy to trip over:
+
+- **`--` must come before the binary path.** It separates Claude Code’s own options from the command that runs the server.
+- **Don’t put the server name straight after `--env`.** `--env` accepts multiple `KEY=value` pairs, so `paycrest` would be read as another pair and rejected. Keep at least one other option (`--transport`, `--scope`) between them, as above.
+
+Write out the full Windows path — `%USERPROFILE%` is not expanded here.
+</Warning>
+
+### Choose a scope
+
+| Scope | Loads in | Stored in |
+|-------|----------|-----------|
+| `local` (default) | Current project only | `~/.claude.json` |
+| `project` | Current project, shared with your team | `.mcp.json` in the repo root |
+| `user` | All your projects | `~/.claude.json` |
+
+Use **`--scope user`** for Paycrest — a payments agent isn’t tied to one repo.
+
+### Verify
+
+```bash
+claude mcp list
+```
+
+`paycrest` should show **`✔ Connected`**. Inside a Claude Code session, `/mcp` shows the same status and lets you inspect the server’s tools. To start over, run `claude mcp remove paycrest` and add it again.
+
+### Project config (`.mcp.json`)
+
+If you’d rather commit the server for your whole team, add it at project scope and Claude Code writes `.mcp.json` in the repo root:
+
+<CodeGroup>
+
+```json Windows
+{
+  "mcpServers": {
+    "paycrest": {
+      "command": "C:/Users/YOU/.paycrest/paycrest-mcp.exe",
+      "env": {
+        "PAYCREST_API_KEY": "your-sender-api-key"
+      }
+    }
+  }
+}
+```
+
+```json macOS / Linux
+{
+  "mcpServers": {
+    "paycrest": {
+      "command": "/Users/YOU/.paycrest/paycrest-mcp",
+      "env": {
+        "PAYCREST_API_KEY": "your-sender-api-key"
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+<Warning>
+`.mcp.json` is meant to be committed. Don’t put a real sender API key in it — keep the key at user scope, or have each teammate set `PAYCREST_API_KEY` in their own environment.
+</Warning>
+
+## Connect Cursor
+
+The installer may already have done this — open `~/.cursor/mcp.json` and check for a `paycrest` entry before editing.
 
 Typical config after install (path may match your username):
 
@@ -110,15 +209,15 @@ After install or editing `mcp.json`:
 
 Confirm **paycrest** shows as connected / no error on the server.
 
-## Configure VS Code (`mcp.json`)
+## Connect VS Code
 
-VS Code uses the same installed binary, but its MCP config shape is different from Cursor’s.
+The installer does not touch VS Code either, and its MCP config shape differs from Cursor’s.
 
 <Note>
-VS Code uses `"servers"` at the top level. Cursor uses `"mcpServers"`.
+VS Code uses `"servers"` at the top level and requires `"type": "stdio"`. Cursor and Claude Code use `"mcpServers"`.
 </Note>
 
-Open **Command Palette → MCP: Open User Configuration**, then add:
+Open **Command Palette → MCP: Open User Configuration** (or **MCP: Add Server** for a guided flow), then add:
 
 <CodeGroup>
 
@@ -152,16 +251,42 @@ Open **Command Palette → MCP: Open User Configuration**, then add:
 
 </CodeGroup>
 
-After saving:
+### Keep the key out of the file
+
+VS Code can prompt for the key instead of storing it in plain text. Use an `inputs` entry and reference it from `env`:
+
+```json
+{
+  "inputs": [
+    {
+      "id": "paycrest-api-key",
+      "type": "promptString",
+      "description": "Paycrest sender API key",
+      "password": true
+    }
+  ],
+  "servers": {
+    "paycrest": {
+      "type": "stdio",
+      "command": "/Users/YOU/.paycrest/paycrest-mcp",
+      "env": {
+        "PAYCREST_API_KEY": "${input:paycrest-api-key}"
+      }
+    }
+  }
+}
+```
+
+### Start the server
 
 1. Open **GitHub Copilot Chat**.
 2. Switch chat mode to **Agent**.
-3. Start or enable the `paycrest` MCP server when VS Code prompts.
+3. Start or enable the `paycrest` MCP server when VS Code prompts (or run **MCP: List Servers**).
 4. Try the smoke tests below.
 
 ## Smoke tests
 
-In Cursor Agent or VS Code Copilot Agent, try:
+In Claude Code, Cursor Agent, or VS Code Copilot Chat (**Agent** mode), try:
 
 - “List Paycrest currencies”
 - “What’s the rate for 100 USDC on base to NGN?”
@@ -214,22 +339,30 @@ paid
 
 ## Upgrade
 
-1. **Quit Cursor completely** first (the running MCP holds a lock on the `.exe` / binary).
+1. **Quit every client running the server** — exit your Claude Code sessions, quit Cursor, quit VS Code. The running MCP process holds a lock on the `.exe` / binary.
 2. Re-run the same install one-liner.
-3. Open Cursor and reload MCP if needed.
+3. Reconnect:
+   - **Claude Code** — start a new session, then `claude mcp list`
+   - **Cursor** — **Cursor Settings → Tools & MCP**
+   - **VS Code** — restart the `paycrest` server from **MCP: List Servers**
 
-If you skip quitting Cursor, Windows often fails with “file in use” / access denied.
+If a client is still running, Windows often fails with “file in use” / access denied.
+
+<Note>
+Re-running the installer replaces the **binary** only. Your client config and API key are untouched.
+</Note>
 
 ## Troubleshooting
 
 | Problem | What to do |
 |---------|------------|
 | `irm` / curl returns **404** | Repo or raw script URL not reachable. Use a [Release](https://github.com/paycrest/sender-mcp/releases) download, or clone and run `.\scripts\install.ps1` / `./scripts/install.sh` with `gh auth login`. |
-| **File in use** / cannot overwrite binary | Quit Cursor fully, then re-run install. |
+| **File in use** / cannot overwrite binary | Quit **every** MCP client running the server — Claude Code sessions, Cursor, VS Code — then re-run install. |
 | Install fails in **Git Bash** | Use **PowerShell** on Windows for `irm … \| iex`. |
-| Auth / **401** / sender tools fail | Check `PAYCREST_API_KEY` in `~/.cursor/mcp.json` — wrong, expired, or missing key. Reload MCP after fixing. |
+| Auth / **401** / sender tools fail | Check `PAYCREST_API_KEY` in your client’s config (see [Where the config lives](#where-the-config-lives)) — wrong, expired, or missing key. In Claude Code, `claude mcp remove paycrest` then re-run the add command. Reload MCP after fixing. |
 | Downloaded something that isn’t an app | Ignore **Source code (zip/tar.gz)** on Releases. Use the platform asset (e.g. `…_windows_amd64.exe`, `…_darwin_arm64`). |
-| MCP server red / not listed | Confirm `command` path exists, then reload MCP / restart Cursor. |
+| MCP server red / not listed / failed to connect | Confirm the `command` path exists (`ls ~/.paycrest`), then reload: `claude mcp list` (Claude Code), **Cursor Settings → Tools & MCP**, or **MCP: List Servers** (VS Code). |
+| `claude mcp add` rejected the name, or the server never starts | Flag order. `--env` must not sit immediately before the server name, and `--` must come before the binary path. Run `claude mcp remove paycrest`, then re-run the exact command above. |
 
 ## Links
 

--- a/implementation-guides/sender-mcp.mdx
+++ b/implementation-guides/sender-mcp.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Sender MCP"
-description: "Install and use the Paycrest Sender MCP in Cursor to create and track payment orders with natural language."
+description: "Install and use the Paycrest Sender MCP in Cursor or VS Code to create and track payment orders with natural language."
 ---
 
-Use **Paycrest** from **Cursor** through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). A small app runs on your machine, talks to the Paycrest API, and lets the Cursor agent create and track payment orders in plain language.
+Use **Paycrest** from **Cursor** or **VS Code** through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). A small app runs on your machine, talks to the Paycrest API, and lets your AI agent create and track payment orders in plain language.
 
-You do **not** need Go or a local clone for normal use — only Cursor and a sender API key.
+You do **not** need Go or a local clone for normal use — only an MCP-capable editor and a sender API key.
 
 For HTTP API integration (apps and backends), see [Sender API Integration](/implementation-guides/sender-api-integration).
 
 ## Prerequisites
 
-1. **[Cursor](https://cursor.com/)** installed
+1. **[Cursor](https://cursor.com/)** or **[VS Code](https://code.visualstudio.com/)** with GitHub Copilot Chat installed
 2. A **sender API key** from the [Paycrest dashboard](https://paycrest.io) (Settings → API keys)
 
 ## Install
@@ -41,7 +41,7 @@ curl -fsSL https://raw.githubusercontent.com/paycrest/sender-mcp/main/scripts/in
 
 1. Downloads the matching binary from [Releases](https://github.com/paycrest/sender-mcp/releases)
 2. Saves it under `~/.paycrest/` with a fixed name (no manual rename)
-3. Merges a `paycrest` entry into `~/.cursor/mcp.json` (unless you skip that step)
+3. Merges a `paycrest` entry into Cursor’s `~/.cursor/mcp.json` (unless you skip that step)
 
 <Note>
 Ignore the **Source code (zip/tar.gz)** links on the Releases page — those are source archives, not the MCP binary.
@@ -110,9 +110,58 @@ After install or editing `mcp.json`:
 
 Confirm **paycrest** shows as connected / no error on the server.
 
+## Configure VS Code (`mcp.json`)
+
+VS Code uses the same installed binary, but its MCP config shape is different from Cursor’s.
+
+<Note>
+VS Code uses `"servers"` at the top level. Cursor uses `"mcpServers"`.
+</Note>
+
+Open **Command Palette → MCP: Open User Configuration**, then add:
+
+<CodeGroup>
+
+```json Windows
+{
+  "servers": {
+    "paycrest": {
+      "type": "stdio",
+      "command": "C:/Users/YOU/.paycrest/paycrest-mcp.exe",
+      "env": {
+        "PAYCREST_API_KEY": "your-sender-api-key"
+      }
+    }
+  }
+}
+```
+
+```json macOS / Linux
+{
+  "servers": {
+    "paycrest": {
+      "type": "stdio",
+      "command": "/Users/YOU/.paycrest/paycrest-mcp",
+      "env": {
+        "PAYCREST_API_KEY": "your-sender-api-key"
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+After saving:
+
+1. Open **GitHub Copilot Chat**.
+2. Switch chat mode to **Agent**.
+3. Start or enable the `paycrest` MCP server when VS Code prompts.
+4. Try the smoke tests below.
+
 ## Smoke tests
 
-In Cursor chat, try:
+In Cursor Agent or VS Code Copilot Agent, try:
 
 - “List Paycrest currencies”
 - “What’s the rate for 100 USDC on base to NGN?”

--- a/implementation-guides/sender-mcp.mdx
+++ b/implementation-guides/sender-mcp.mdx
@@ -1,0 +1,189 @@
+---
+title: "Sender MCP"
+description: "Install and use the Paycrest Sender MCP in Cursor to create and track payment orders with natural language."
+---
+
+Use **Paycrest** from **Cursor** through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). A small app runs on your machine, talks to the Paycrest API, and lets the Cursor agent create and track payment orders in plain language.
+
+You do **not** need Go or a local clone for normal use — only Cursor and a sender API key.
+
+For HTTP API integration (apps and backends), see [Sender API Integration](/implementation-guides/sender-api-integration).
+
+## Prerequisites
+
+1. **[Cursor](https://cursor.com/)** installed
+2. A **sender API key** from the [Paycrest dashboard](https://paycrest.io) (Settings → API keys)
+
+## Install
+
+The installer downloads the latest release binary to a **fixed path** and can wire Cursor’s MCP config for you.
+
+| OS | Binary path |
+|----|-------------|
+| Windows | `%USERPROFILE%\.paycrest\paycrest-mcp.exe` |
+| macOS / Linux | `~/.paycrest/paycrest-mcp` |
+
+### Windows (PowerShell — not Git Bash)
+
+Open **Windows PowerShell** (or Terminal → PowerShell). Do **not** use Git Bash for this one-liner.
+
+```powershell
+irm https://raw.githubusercontent.com/paycrest/sender-mcp/main/scripts/install.ps1 | iex
+```
+
+### macOS / Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/paycrest/sender-mcp/main/scripts/install.sh | bash
+```
+
+### What the script does
+
+1. Downloads the matching binary from [Releases](https://github.com/paycrest/sender-mcp/releases)
+2. Saves it under `~/.paycrest/` with a fixed name (no manual rename)
+3. Merges a `paycrest` entry into `~/.cursor/mcp.json` (unless you skip that step)
+
+<Note>
+Ignore the **Source code (zip/tar.gz)** links on the Releases page — those are source archives, not the MCP binary.
+</Note>
+
+## Configure Cursor (`mcp.json`)
+
+You only need **`PAYCREST_API_KEY`**.
+
+Typical config after install (path may match your username):
+
+<CodeGroup>
+
+```json Windows
+{
+  "mcpServers": {
+    "paycrest": {
+      "command": "C:/Users/YOU/.paycrest/paycrest-mcp.exe",
+      "env": {
+        "PAYCREST_API_KEY": "your-sender-api-key"
+      }
+    }
+  }
+}
+```
+
+```json macOS / Linux
+{
+  "mcpServers": {
+    "paycrest": {
+      "command": "/Users/YOU/.paycrest/paycrest-mcp",
+      "env": {
+        "PAYCREST_API_KEY": "your-sender-api-key"
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+### Set your API key in Cursor
+
+Open the MCP settings (**Cursor Settings → Tools & MCP**) and edit the `paycrest` server’s JSON to replace `your-sender-api-key` with your key.
+
+<Tabs>
+  <Tab title="Windows">
+    1. **Hover** over the **paycrest** MCP server.
+    2. Click the **edit** (pencil) icon.
+    3. Update `PAYCREST_API_KEY` in the JSON with your key.
+  </Tab>
+  <Tab title="macOS">
+    1. Click the **three dots** on the right of the **paycrest** MCP server.
+    2. Click **Configure**.
+    3. Choose **User**.
+    4. Update `PAYCREST_API_KEY` in the JSON with your key.
+  </Tab>
+</Tabs>
+
+### Reload MCP
+
+After install or editing `mcp.json`:
+
+1. Open **Cursor Settings → Tools & MCP**, or
+2. Restart Cursor
+
+Confirm **paycrest** shows as connected / no error on the server.
+
+## Smoke tests
+
+In Cursor chat, try:
+
+- “List Paycrest currencies”
+- “What’s the rate for 100 USDC on base to NGN?”
+
+If those succeed, the MCP server and API key are working.
+
+## Order flow (create → pay → watch)
+
+Typical flow the agent should follow:
+
+<Steps>
+  <Step title="Create">
+    Create an order (onramp or offramp) via natural language.
+  </Step>
+  <Step title="Pay-in details">
+    The agent shows pay-in details (bank / wallet / account info) and the order id.
+  </Step>
+  <Step title="Send funds">
+    You send the funds (fiat or crypto, as instructed).
+  </Step>
+  <Step title="Confirm payment">
+    Reply **`paid`** (or “I have paid” / “transfer confirmed”).
+  </Step>
+  <Step title="Watch until terminal">
+    The agent runs **one continuous watch** until the order is **settled**, **cancelled**, **refunded**, or **expired**.
+  </Step>
+</Steps>
+
+You can also use the MCP prompt **“After payment — watch order”** and paste the order id if the chat lost context.
+
+### Example prompts
+
+**Offramp** (crypto → fiat):
+
+```text
+offramp 0.5 USDC Base, refund 0x0c89b146E1dB0A1cf325e0bBA4FfFF24e3F1d0D4, NGN OPay 0987654321, John Doe.
+```
+
+**Onramp** (fiat → crypto):
+
+```text
+onramp 1000 NGN to USDC on Base at 0xCfb28A38b6083B2Ef0B4F99C7cC3aB76b71F0426, refund OPay 0987654321, name John Doe.
+```
+
+After you’ve paid:
+
+```text
+paid
+```
+
+## Upgrade
+
+1. **Quit Cursor completely** first (the running MCP holds a lock on the `.exe` / binary).
+2. Re-run the same install one-liner.
+3. Open Cursor and reload MCP if needed.
+
+If you skip quitting Cursor, Windows often fails with “file in use” / access denied.
+
+## Troubleshooting
+
+| Problem | What to do |
+|---------|------------|
+| `irm` / curl returns **404** | Repo or raw script URL not reachable. Use a [Release](https://github.com/paycrest/sender-mcp/releases) download, or clone and run `.\scripts\install.ps1` / `./scripts/install.sh` with `gh auth login`. |
+| **File in use** / cannot overwrite binary | Quit Cursor fully, then re-run install. |
+| Install fails in **Git Bash** | Use **PowerShell** on Windows for `irm … \| iex`. |
+| Auth / **401** / sender tools fail | Check `PAYCREST_API_KEY` in `~/.cursor/mcp.json` — wrong, expired, or missing key. Reload MCP after fixing. |
+| Downloaded something that isn’t an app | Ignore **Source code (zip/tar.gz)** on Releases. Use the platform asset (e.g. `…_windows_amd64.exe`, `…_darwin_arm64`). |
+| MCP server red / not listed | Confirm `command` path exists, then reload MCP / restart Cursor. |
+
+## Links
+
+- [GitHub Releases (binaries)](https://github.com/paycrest/sender-mcp/releases)
+- [sender-mcp repository](https://github.com/paycrest/sender-mcp)
+- [Sender API Integration](/implementation-guides/sender-api-integration)

--- a/implementation-guides/sender-mcp.mdx
+++ b/implementation-guides/sender-mcp.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Sender MCP"
-description: "Install and use the Paycrest Sender MCP in Cursor or VS Code to create and track payment orders with natural language."
+title: "Sender Agent Guide"
+description: "Install and use the Paycrest sender agent (MCP) in Cursor or VS Code to create and track payment orders with natural language."
 ---
 
 Use **Paycrest** from **Cursor** or **VS Code** through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). A small app runs on your machine, talks to the Paycrest API, and lets your AI agent create and track payment orders in plain language.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -9,23 +9,6 @@ Paycrest is a **decentralized payment routing protocol** for stablecoin-fiat pay
 
 Paycrest is built for **wallets, fintechs, exchanges, DeFi protocols, and platforms** that need to move stablecoins into and out of local fiat accounts in high-friction markets. If you're building a product that touches cross-border payments, remittances, payroll, or stablecoin on/offramps — Paycrest is the routing layer.
 
-## Traction
-
-<CardGroup cols={2}>
-  <Card title="$3.4M+" icon="dollar-sign">
-    Total payment volume settled
-  </Card>
-  <Card title="28,500+" icon="arrow-right-arrow-left">
-    Settled orders processed
-  </Card>
-  <Card title="$774K" icon="chart-line">
-    Peak monthly volume (December 2025)
-  </Card>
-  <Card title="< 30 seconds" icon="clock">
-    Median NGN settlement time
-  </Card>
-</CardGroup>
-
 ## The Problem
 
 Cross-border payments, especially in Africa and other emerging markets, remain globally expensive, slow, and fragmented. Sending money from the US to Nigeria costs an average of 6–8% in fees and takes 1–3 business days. For the $54 billion in annual remittances flowing into Sub-Saharan Africa, that translates to billions lost to intermediaries every year.
@@ -112,7 +95,7 @@ The key properties:
 
 ## Supported Corridors
 
-Paycrest is live across 6 active corridors with real provider liquidity. New corridors launch only when committed providers are onboarded and tested.
+Paycrest is live across 4 active corridors with real provider liquidity. New corridors launch only when committed providers are onboarded and tested.
 
 <CardGroup cols={2}>
   <Card title="African Markets" icon="globe">
@@ -121,13 +104,11 @@ Paycrest is live across 6 active corridors with real provider liquidity. New cor
       <li>KES 🇰🇪 — Kenyan Shilling</li>
       <li>UGX 🇺🇬 — Ugandan Shilling</li>
       <li>TZS 🇹🇿 — Tanzanian Shilling</li>
-      <li>MWK 🇲🇼 — Malawian Kwacha</li>
     </ul>
   </Card>
-  <Card title="Latin American Markets" icon="globe">
+  <Card title="Coming Soon" icon="globe">
     <ul>
-      <li>BRL 🇧🇷 — Brazilian Real</li>
-      <li>More coming in Q3 2026 (Argentina)</li>
+      <li>More corridors in Q3 2026 (e.g. Argentina)</li>
     </ul>
   </Card>
 </CardGroup>

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -471,7 +471,7 @@ components:
           description: |
             Bank account number, mobile wallet MSISDN, Till/Paybill identifier, or other account identifier.
 
-            For **mobile_money** institutions, the API normalizes phone numbers before verification: strips `+`, removes a leading domestic `0`, and adds the country dial code when missing (KES 254, UGX 256, TZS 255, GHS 233, MWK 265). Examples for KES M-Pesa — `0712345678`, `+254712345678`, and `254712345678` all normalize to `254712345678`.
+            For **mobile_money** institutions, the API normalizes phone numbers before verification: strips `+`, removes a leading domestic `0`, and adds the country dial code when missing (KES 254, UGX 256, TZS 255, GHS 233). Examples for KES M-Pesa — `0712345678`, `+254712345678`, and `254712345678` all normalize to `254712345678`.
 
             KES Till/Paybill identifiers are not normalized when `metadata` indicates Till/Paybill, or when the value looks like Paybill (`business|reference`) or Till (fewer than 9 digits).
         metadata:

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -688,7 +688,7 @@ components:
           description: |
             Bank account number, mobile wallet MSISDN, Till/Paybill identifier, or other account identifier.
 
-            For **mobile_money** institutions, the API normalizes phone numbers before verification: strips `+`, removes a leading domestic `0`, and adds the country dial code when missing (KES 254, UGX 256, TZS 255, GHS 233, MWK 265). Examples for KES M-Pesa — `0712345678`, `+254712345678`, and `254712345678` all normalize to `254712345678`.
+            For **mobile_money** institutions, the API normalizes phone numbers before verification: strips `+`, removes a leading domestic `0`, and adds the country dial code when missing (KES 254, UGX 256, TZS 255, GHS 233). Examples for KES M-Pesa — `0712345678`, `+254712345678`, and `254712345678` all normalize to `254712345678`.
 
             KES Till/Paybill identifiers are not normalized when `metadata` indicates Till/Paybill, or when the value looks like Paybill (`business|reference`) or Till (fewer than 9 digits).
         metadata:
@@ -808,7 +808,7 @@ components:
           enum: [fiat]
         currency:
           type: string
-          description: Fiat currency code (e.g. NGN, KES, BRL)
+          description: Fiat currency code (e.g. NGN, KES, TZS)
         country:
           type: string
           description: ISO 3166-1 alpha-2 country code (optional)

--- a/protocol-overview.mdx
+++ b/protocol-overview.mdx
@@ -3,7 +3,7 @@ title: "Protocol Overview"
 description: "Deep dive into the Paycrest protocol architecture, participants, and core components"
 ---
 
-Paycrest is a decentralized payment routing protocol for stablecoin-fiat payments in emerging markets. It handles the full stack — order routing, encrypted message passing, onchain escrow, provider matching, and fiat execution — without ever custodying user funds. This page covers the core architecture, participants, and key technical components. For traction, roadmap, and competitive positioning, see the [Introduction](/introduction).
+Paycrest is a decentralized payment routing protocol for stablecoin-fiat payments in emerging markets. It handles the full stack — order routing, encrypted message passing, onchain escrow, provider matching, and fiat execution — without ever custodying user funds. This page covers the core architecture, participants, and key technical components. For product overview, roadmap, and competitive positioning, see the [Introduction](/introduction).
 
 ## Protocol Vision
 
@@ -227,7 +227,7 @@ Providers earn fees by:
 ### Delivery Methods
 
 - **Bank Transfer**: Direct deposit to local bank account
-- **Mobile**: Transfer to mobile wallet (M-Pesa, etc.) or mobile payment systems (UPI, PIX)
+- **Mobile**: Transfer to mobile wallet (M-Pesa, etc.) or other mobile payment systems
 - **Crypto Wallet**: Receive stablecoins in specified wallet
 
 <Callout type="warning">Cash pickup is not supported. All off-ramps are to fiat accounts or wallets.</Callout>

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -47,7 +47,7 @@ See [Webhook delivery logs & retry](/implementation-guides/sender-api-integratio
 
 ### Verify-account mobile money normalization (June 2026)
 
-**`POST /v1/verify-account`** and **`POST /v2/verify-account`** now normalize **mobile_money** `accountIdentifier` values before provider verification (country dial code, strip `+` and leading `0`). Supported fiat dial codes: KES `254`, UGX `256`, TZS `255`, GHS `233`, MWK `265`.
+**`POST /v1/verify-account`** and **`POST /v2/verify-account`** now normalize **mobile_money** `accountIdentifier` values before provider verification (country dial code, strip `+` and leading `0`). Supported fiat dial codes: KES `254`, UGX `256`, TZS `255`, GHS `233`.
 
 - Optional request field **`metadata`** (KES Till/Paybill) skips normalization when appropriate.
 - Response **`data`** may still be `"OK"` when the account is valid but no display name is returned (e.g. some M-Pesa corridors).
@@ -169,10 +169,6 @@ cNGN (Compliant Naira) is now supported as a stablecoin across Ethereum, Base, P
 ### Lisk network support
 
 Lisk (chain ID 1135) added to the aggregator. Gateway contract: `0xff0E00E0110C1FBb5315D276243497b66D3a4d8a`.
-
-### BRL corridor live
-
-Brazilian Real (BRL) via PIX now available as an active corridor. Mobile/PIX delivery only.
 
 ### Protocol launch (February 2025)
 

--- a/resources/code-standards.mdx
+++ b/resources/code-standards.mdx
@@ -14,8 +14,6 @@ Paycrest uses **ISO 4217** standard currency codes, which are the internationall
 - **KES** - Kenyan Shilling  
 - **UGX** - Ugandan Shilling
 - **TZS** - Tanzanian Shilling
-- **MWK** - Malawi Kwacha
-- **BRL** - Brazilian Real
 
 <Note>
   All currency codes used in Paycrest API calls must follow the ISO 4217 standard. These codes are case-sensitive and should be provided in uppercase.

--- a/resources/supported-currencies.mdx
+++ b/resources/supported-currencies.mdx
@@ -13,8 +13,6 @@ Paycrest supports fiat currencies across multiple countries and regions, with de
 | **Kenya** | 🇰🇪 | Kenyan Shilling | KES | Bank, Mobile |
 | **Uganda** | 🇺🇬 | Ugandan Shilling | UGX | Bank, Mobile |
 | **Tanzania** | 🇹🇿 | Tanzanian Shilling | TZS | Bank, Mobile |
-| **Malawi** | 🇲🇼 | Malawi Kwacha | MWK | Bank, Mobile |
-| **Brazil** | 🇧🇷 | Brazilian Real | BRL | Mobile (PIX) |
 
 ## Delivery Channel Matrix
 
@@ -24,8 +22,6 @@ Paycrest supports fiat currencies across multiple countries and regions, with de
 | **KES** | ✅ | ✅ |
 | **UGX** | ✅ | ✅ |
 | **TZS** | ✅ | ✅ |
-| **MWK** | ✅ | ✅ |
-| **BRL** | ❌ | ✅ (PIX) |
 
 ## Integration Examples
 
@@ -104,29 +100,6 @@ recipient: {
   memo: "Bill pay",
   metadata: { channel: "Paybill", businessNumber: "400200" }
 }
-```
-
-### PIX (Brazil)
-```javascript
-const order = {
-  amount: "200",
-  source: {
-    type: "crypto",
-    currency: "USDT",
-    network: "arbitrum-one",
-    refundAddress: "0xYourAddress"
-  },
-  destination: {
-    type: "fiat",
-    currency: "BRL",
-    recipient: {
-      institution: "PIXKBRPC",
-      accountIdentifier: "johndoe@email.com",
-      accountName: "João Silva",
-      memo: "PIX payment"
-    }
-  }
-};
 ```
 
 ## Rate Information


### PR DESCRIPTION
### Description

Adds a **Sender MCP** implementation guide so senders can install and use Paycrest from Cursor or VS Code with natural language.

### Changes
- New page: `implementation-guides/sender-mcp.mdx`
  - Install one-liners (Windows / macOS / Linux)
  - Cursor `mcp.json` setup and how to set `PAYCREST_API_KEY` in the UI
  - VS Code `mcp.json` setup (`servers` + Copilot Agent mode)
  - Smoke tests, order flow, example prompts, upgrade, troubleshooting
- Wired into `docs.json` under **Implementation Guides**
- Cross-link from Sender API Integration → Sender MCP

<img width="1614" height="1274" alt="image" src="https://github.com/user-attachments/assets/b48fb05d-1d55-41c4-adca-7e154eaa781e" />


### Testing
- [x] Local preview with `mint dev`
- [x] Page loads at `/implementation-guides/sender-mcp`
- [x] Sidebar entry appears under Implementation Guides
- [ ] Spot-check Cursor and VS Code config sections for accuracy