### PR TITLE
docs: add Starknet support across documentation and API specifications

### DIFF
--- a/api-reference/general/get-token-rate.mdx
+++ b/api-reference/general/get-token-rate.mdx
@@ -13,7 +13,7 @@ Get buy and/or sell quotes on a **specific network**—either a **token + fiat**
 
 | Parameter | Description |
 |-----------|-------------|
-| `network` | Network id: `ethereum`, `base`, `bnb-smart-chain`, `lisk`, `scroll`, `celo`, `arbitrum-one`, `polygon`, `asset-chain` |
+| `network` | Network id: `ethereum`, `base`, `bnb-smart-chain`, `lisk`, `celo`, `arbitrum-one`, `polygon`, `starknet`, `tron` |
 | `from` | Fiat currency code **or** token symbol on `network` (paired with `to`) |
 | `amount` | For **token + fiat**: crypto (token) notional. For **fiat + fiat**: amount in **`from`** fiat. |
 | `to` | Fiat currency code **or** token symbol on `network` (paired with `from`) |

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -140,7 +140,7 @@ The **aggregator node** is the coordination layer: it monitors onchain events, m
 
 ## Multi-Chain Support
 
-The protocol is live on 8 EVM-compatible networks plus Starknet:
+The protocol is live on 7 EVM-compatible networks plus Starknet and Tron:
 
 | Network | Chain ID | Primary Use |
 |---------|----------|-------------|
@@ -151,10 +151,10 @@ The protocol is live on 8 EVM-compatible networks plus Starknet:
 | BNB Smart Chain | 56 | USDT, USDC, cNGN |
 | Lisk | 1135 | USDT, USDC |
 | Celo | 42220 | USDT, USDC |
-| Scroll | 534352 | USDT, USDC |
-| Starknet | SN_MAIN | USDT, USDC |
+| Starknet | 23448594291968334 | USDT, USDC |
+| Tron | 728126428 | USDT |
 
-Use the API network identifier **`starknet`** when creating orders. Starknet addresses are felt-sized hex (`0x` + up to 64 hex digits), not EVM checksum addresses.
+Use API network identifiers **`starknet`** and **`tron`** when creating orders. Starknet addresses are felt-sized hex (`0x` + up to 64 hex digits). Tron addresses are Base58Check and start with `T`.
 
 See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for the full deployment table, and [Supported Stablecoins](/resources/supported-stablecoins) for per-network token details.
 

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -140,7 +140,7 @@ The **aggregator node** is the coordination layer: it monitors onchain events, m
 
 ## Multi-Chain Support
 
-The protocol is live on 8 EVM-compatible networks:
+The protocol is live on 8 EVM-compatible networks plus Starknet:
 
 | Network | Chain ID | Primary Use |
 |---------|----------|-------------|
@@ -152,6 +152,9 @@ The protocol is live on 8 EVM-compatible networks:
 | Lisk | 1135 | USDT, USDC |
 | Celo | 42220 | USDT, USDC |
 | Scroll | 534352 | USDT, USDC |
+| Starknet | SN_MAIN | USDT, USDC |
+
+Use the API network identifier **`starknet`** when creating orders. Starknet addresses are felt-sized hex (`0x` + up to 64 hex digits), not EVM checksum addresses.
 
 See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for the full deployment table, and [Supported Stablecoins](/resources/supported-stablecoins) for per-network token details.
 

--- a/implementation-guides/provider-setup-guide.mdx
+++ b/implementation-guides/provider-setup-guide.mdx
@@ -175,6 +175,7 @@ Expected response:
 - Add settlement addresses for all supported networks and tokens
 - You can add a settlement address on multiple networks for flexibility
 - For **Starknet**, use a Starknet wallet address (`0x` + 63–64 hex characters), not an EVM address — network identifier is `starknet`
+- For **Tron**, use a Tron Base58 address (starts with `T`), not an EVM address — network identifier is `tron`
 
 ### Step 6: Node Testing & Launch
 

--- a/implementation-guides/provider-setup-guide.mdx
+++ b/implementation-guides/provider-setup-guide.mdx
@@ -82,7 +82,9 @@ CURRENCIES=KES # single currency
 # CURRENCIES=NGN,KES,UGX # multiple currencies must be comma-separated
 ENVIRONMENT=production # local, staging, production
 SERVER_URL=https://your-server-domain-or-ip
-EVM_PRIVATE_KEY= # required for onramp settlements
+EVM_PRIVATE_KEY= # required for EVM onramp settlements
+STARKNET_SNIP9_USER_ADDRESS= # required for Starknet onramp (payin)
+STARKNET_SNIP9_PRIVATE_KEY= # required for Starknet onramp (payin)
 
 # Aggregator Config
 AGGREGATOR_CLIENT_ID=your_paycrest_api_key # Provider Dashboard → Settings → Payout → API Keys
@@ -92,9 +94,7 @@ AGGREGATOR_BASE_URL=https://api.paycrest.io/v2/provider
 # PSP Config - Only configure for PSPs you are using
 # Example env prefix (Payaza — names shown in dashboard; availability varies by corridor/currency)
 PAYAZA_API_KEY=
-PAYAZA_BASE_URL=
 PAYAZA_TRANSACTION_PIN=
-PAYAZA_SUPPORTS_PAYIN=false
 ```
 
 > **Credential Mapping**
@@ -105,9 +105,18 @@ PAYAZA_SUPPORTS_PAYIN=false
 #### `EVM_PRIVATE_KEY` explained
 
 - **What it is**: The private key for a dedicated EVM wallet (EOA) used by your provision node.
-- **When you need it**: Required for onramp-related wallet/authorization flows. If you're running offramp-only operations, you can leave it unset.
+- **When you need it**: Required for EVM onramp-related wallet/authorization flows. If you're running offramp-only operations, you can leave it unset.
 - **How to generate it**: Create a new dedicated EVM wallet (do not reuse a personal wallet) and use that wallet's private key.
 - **Security**: Treat this as a production secret. Never commit it to git, store it in a secure secret manager or protected `.env`, and rotate it immediately if exposed.
+
+#### Starknet onramp envs explained
+
+- **What they are**:
+  - `STARKNET_SNIP9_USER_ADDRESS` — Starknet account address used to sign SNIP-9 OutsideExecution payin messages
+  - `STARKNET_SNIP9_PRIVATE_KEY` — private key for that Starknet account
+- **When you need them**: Required when fulfilling **Starknet onramp (payin)** orders. If you only handle EVM/Tron or offramp-only flows, you can leave them unset.
+- **Address format**: Use a Starknet felt hex address (`0x` + 63–64 hex characters), not an EVM checksum address.
+- **Security**: Treat both as production secrets. Never commit them to git, store them in a secure secret manager or protected `.env`, and rotate them immediately if exposed.
 
 > **Important Notes:**
 > - One node works for multiple currencies and can support multiple PSPs (for the same currency)

--- a/implementation-guides/provider-setup-guide.mdx
+++ b/implementation-guides/provider-setup-guide.mdx
@@ -174,6 +174,7 @@ Expected response:
 **Configure Networks**
 - Add settlement addresses for all supported networks and tokens
 - You can add a settlement address on multiple networks for flexibility
+- For **Starknet**, use a Starknet wallet address (`0x` + 63–64 hex characters), not an EVM address — network identifier is `starknet`
 
 ### Step 6: Node Testing & Launch
 

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -89,7 +89,7 @@ In the dashboard settings, you can set defaults per token/network. **Offramp:** 
 Pass a `source` and a `destination` object. The `type` field on each determines the direction. **Offramp** and **onramp** use the same endpoint; examples below include **`curl`** for both directions. The extra **JavaScript** and **Python** snippets are **offramp**-shaped—mirror the **onramp** `curl` payload (`source.type: "fiat"`, `destination.type: "crypto"`, `refundAccount`, etc.) in your language.
 
 <Note>
-  **Starknet:** set `network` to **`starknet`**. Crypto addresses (`source.refundAddress` on offramp, `destination.recipient.address` on onramp) must be Starknet felt hex (`0x` + 63–64 hex digits). Do not pass EVM checksum addresses. See [Supported Stablecoins](/resources/supported-stablecoins) for USDT/USDC contract addresses on Starknet.
+  **Starknet / Tron:** set `network` to **`starknet`** or **`tron`**. Crypto addresses (`source.refundAddress` on offramp, `destination.recipient.address` on onramp) must match the network: Starknet felt hex (`0x` + 63–64 hex digits) or Tron Base58 (`T…`). Do not pass EVM checksum addresses on these networks. See [Supported Stablecoins](/resources/supported-stablecoins).
 </Note>
 
 <Tabs>
@@ -154,6 +154,38 @@ curl -X POST "https://api.paycrest.io/v2/sender/orders" \
 ```
 
 After create, transfer Starknet USDT/USDC to `providerAccount.receiveAddress` (also a Starknet address) before `validUntil`. Confirm settlement via webhooks or [GET order by ID](/api-reference/sender/get-payment-order-by-id-v2).
+  </Tab>
+  <Tab title="Offramp (Tron)">
+
+Same shape as EVM offramp; use `network: "tron"` and a Tron Base58 refund address (starts with `T`).
+
+```bash
+curl -X POST "https://api.paycrest.io/v2/sender/orders" \
+  -H "API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "100",
+    "source": {
+      "type": "crypto",
+      "currency": "USDT",
+      "network": "tron",
+      "refundAddress": "TYourTronWalletAddress............."
+    },
+    "destination": {
+      "type": "fiat",
+      "currency": "NGN",
+      "recipient": {
+        "institution": "GTBINGLA",
+        "accountIdentifier": "1234567890",
+        "accountName": "John Doe",
+        "memo": "Salary payment"
+      }
+    },
+    "reference": "order-tron-001"
+  }'
+```
+
+After create, transfer Tron USDT to `providerAccount.receiveAddress` (also a Tron address) before `validUntil`. Confirm settlement via webhooks or [GET order by ID](/api-reference/sender/get-payment-order-by-id-v2).
   </Tab>
   <Tab title="Onramp (fiat → stablecoin)">
 

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -88,6 +88,10 @@ In the dashboard settings, you can set defaults per token/network. **Offramp:** 
 
 Pass a `source` and a `destination` object. The `type` field on each determines the direction. **Offramp** and **onramp** use the same endpoint; examples below include **`curl`** for both directions. The extra **JavaScript** and **Python** snippets are **offramp**-shaped—mirror the **onramp** `curl` payload (`source.type: "fiat"`, `destination.type: "crypto"`, `refundAccount`, etc.) in your language.
 
+<Note>
+  **Starknet:** set `network` to **`starknet`**. Crypto addresses (`source.refundAddress` on offramp, `destination.recipient.address` on onramp) must be Starknet felt hex (`0x` + 63–64 hex digits). Do not pass EVM checksum addresses. See [Supported Stablecoins](/resources/supported-stablecoins) for USDT/USDC contract addresses on Starknet.
+</Note>
+
 <Tabs>
   <Tab title="Offramp (stablecoin → fiat)">
 
@@ -118,6 +122,38 @@ curl -X POST "https://api.paycrest.io/v2/sender/orders" \
     "reference": "order-001"
   }'
 ```
+  </Tab>
+  <Tab title="Offramp (Starknet)">
+
+Same shape as EVM offramp; use `network: "starknet"` and a Starknet refund address.
+
+```bash
+curl -X POST "https://api.paycrest.io/v2/sender/orders" \
+  -H "API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "100",
+    "source": {
+      "type": "crypto",
+      "currency": "USDT",
+      "network": "starknet",
+      "refundAddress": "0x046a056257607e1126a73b789bc6b56216e260261d4b54dd0809df46638bcbad"
+    },
+    "destination": {
+      "type": "fiat",
+      "currency": "NGN",
+      "recipient": {
+        "institution": "GTBINGLA",
+        "accountIdentifier": "1234567890",
+        "accountName": "John Doe",
+        "memo": "Salary payment"
+      }
+    },
+    "reference": "order-starknet-001"
+  }'
+```
+
+After create, transfer Starknet USDT/USDC to `providerAccount.receiveAddress` (also a Starknet address) before `validUntil`. Confirm settlement via webhooks or [GET order by ID](/api-reference/sender/get-payment-order-by-id-v2).
   </Tab>
   <Tab title="Onramp (fiat → stablecoin)">
 

--- a/implementation-guides/smart-contract-interaction.mdx
+++ b/implementation-guides/smart-contract-interaction.mdx
@@ -9,6 +9,10 @@ Interact directly with the Paycrest Gateway smart contract for onchain <strong>s
   This guide uses **Viem** for smart contract interactions, which is the recommended Ethereum library for modern applications. Viem provides better TypeScript support, improved performance, and a more intuitive API compared to ethers.js.
 </Note>
 
+<Note>
+  **Starknet:** Gateway is live on Starknet, but this page documents **EVM** contract calls only. For Starknet orders, use the [Sender API Integration](/implementation-guides/sender-api-integration) with `network: "starknet"`. Gateway address and token contracts are listed under [Gateway Contract Addresses](/resources/gateway-contract-addresses) and [Supported Stablecoins](/resources/supported-stablecoins).
+</Note>
+
 ## Overview
 
 The Gateway contract is a multi-chain EVM-based smart contract that facilitates the onchain lifecycle of payment orders. It empowers users to create off-ramp orders while enabling liquidity providers to facilitate those orders at competitive exchange rates.
@@ -1337,6 +1341,7 @@ func main() {
 - **Lisk**: USDT, USDC
 - **Celo**: USDT, USDC
 - **Scroll**: USDT, USDC
+- **Starknet**: USDT, USDC
 
 See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for deployment addresses per network.
 

--- a/implementation-guides/smart-contract-interaction.mdx
+++ b/implementation-guides/smart-contract-interaction.mdx
@@ -10,7 +10,7 @@ Interact directly with the Paycrest Gateway smart contract for onchain <strong>s
 </Note>
 
 <Note>
-  **Starknet:** Gateway is live on Starknet, but this page documents **EVM** contract calls only. For Starknet orders, use the [Sender API Integration](/implementation-guides/sender-api-integration) with `network: "starknet"`. Gateway address and token contracts are listed under [Gateway Contract Addresses](/resources/gateway-contract-addresses) and [Supported Stablecoins](/resources/supported-stablecoins).
+  **Starknet and Tron:** Gateways are live on both networks, but this page documents **EVM** contract calls only. For those orders, use the [Sender API Integration](/implementation-guides/sender-api-integration) with `network: "starknet"` or `network: "tron"`. Addresses and token contracts are listed under [Gateway Contract Addresses](/resources/gateway-contract-addresses) and [Supported Stablecoins](/resources/supported-stablecoins).
 </Note>
 
 ## Overview
@@ -1340,8 +1340,8 @@ func main() {
 - **BNB Smart Chain**: USDT, USDC, cNGN
 - **Lisk**: USDT, USDC
 - **Celo**: USDT, USDC
-- **Scroll**: USDT, USDC
 - **Starknet**: USDT, USDC
+- **Tron**: USDT
 
 See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for deployment addresses per network.
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -146,7 +146,7 @@ Paycrest is live across 6 active corridors with real provider liquidity. New cor
     <ul>
       <li>Ethereum, Base, Arbitrum One</li>
       <li>Polygon, BNB Smart Chain, Lisk</li>
-      <li>Celo, Scroll</li>
+      <li>Celo, Scroll, Starknet</li>
     </ul>
   </Card>
 </CardGroup>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -146,7 +146,7 @@ Paycrest is live across 6 active corridors with real provider liquidity. New cor
     <ul>
       <li>Ethereum, Base, Arbitrum One</li>
       <li>Polygon, BNB Smart Chain, Lisk</li>
-      <li>Celo, Scroll, Starknet</li>
+      <li>Celo, Starknet, Tron</li>
     </ul>
   </Card>
 </CardGroup>

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -38,7 +38,7 @@ components:
           type: number
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         recipient:
           $ref: '#/components/schemas/PaymentOrderRecipient'
@@ -87,7 +87,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         receiveAddress:
           type: string
@@ -126,7 +126,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         gatewayId:
           type: string
@@ -231,7 +231,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         orderType:
           type: string
@@ -381,7 +381,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
 
     # Order Status Schemas
@@ -399,7 +399,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         settlePercent:
           type: string
@@ -587,7 +587,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
             description: Network identifier for the blockchain
         - in: query
           name: ordering
@@ -994,7 +994,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
             description: Network identifier for the blockchain
       responses:
         '200':
@@ -1045,7 +1045,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
             description: Network identifier for the blockchain (optional, filters tokens by network)
         - in: query
           name: provider_id

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -38,7 +38,7 @@ components:
           type: number
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         recipient:
           $ref: '#/components/schemas/PaymentOrderRecipient'
@@ -87,7 +87,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         receiveAddress:
           type: string
@@ -126,7 +126,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         gatewayId:
           type: string
@@ -231,7 +231,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         orderType:
           type: string
@@ -381,7 +381,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
 
     # Order Status Schemas
@@ -399,7 +399,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         settlePercent:
           type: string
@@ -587,7 +587,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+            enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
             description: Network identifier for the blockchain
         - in: query
           name: ordering
@@ -994,7 +994,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+            enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
             description: Network identifier for the blockchain
       responses:
         '200':
@@ -1045,7 +1045,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+            enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
             description: Network identifier for the blockchain (optional, filters tokens by network)
         - in: query
           name: provider_id

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -52,7 +52,7 @@ components:
           type: number
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         recipient:
           $ref: '#/components/schemas/PaymentOrderRecipient'
@@ -101,7 +101,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         receiveAddress:
           type: string
@@ -140,7 +140,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         gatewayId:
           type: string
@@ -245,7 +245,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         orderType:
           type: string
@@ -598,7 +598,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
 
     # Order Status Schemas
@@ -616,7 +616,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Network identifier for the blockchain
         settlePercent:
           type: string
@@ -794,7 +794,7 @@ components:
           description: Stablecoin symbol (e.g. USDT, USDC, cNGN)
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, starknet]
         refundAddress:
           type: string
           description: Wallet address for refunds if the order can't be fulfilled
@@ -908,7 +908,7 @@ components:
           description: Wallet address to receive stablecoins
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon]
+          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, starknet]
 
     V2CryptoProviderAccount:
       type: object
@@ -1674,7 +1674,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
       responses:
         '200':
           description: List of tokens
@@ -1718,7 +1718,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain]
+            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
           description: Blockchain network identifier (lowercase in URL).
         - in: path
           name: from

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -52,7 +52,7 @@ components:
           type: number
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         recipient:
           $ref: '#/components/schemas/PaymentOrderRecipient'
@@ -101,7 +101,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         receiveAddress:
           type: string
@@ -140,7 +140,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         gatewayId:
           type: string
@@ -245,7 +245,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         orderType:
           type: string
@@ -598,7 +598,7 @@ components:
           type: string
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
 
     # Order Status Schemas
@@ -616,7 +616,7 @@ components:
           description: Token symbol (USDT, USDC, cNGN). See [Supported Stablecoins](/resources/supported-stablecoins) for available options.
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Network identifier for the blockchain
         settlePercent:
           type: string
@@ -794,7 +794,7 @@ components:
           description: Stablecoin symbol (e.g. USDT, USDC, cNGN)
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
         refundAddress:
           type: string
           description: Wallet address for refunds if the order can't be fulfilled
@@ -908,7 +908,7 @@ components:
           description: Wallet address to receive stablecoins
         network:
           type: string
-          enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, starknet]
+          enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
 
     V2CryptoProviderAccount:
       type: object
@@ -1674,7 +1674,7 @@ paths:
           name: network
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+            enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
       responses:
         '200':
           description: List of tokens
@@ -1718,7 +1718,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [ethereum, base, bnb-smart-chain, lisk, scroll, celo, arbitrum-one, polygon, asset-chain, starknet]
+            enum: [ethereum, base, bnb-smart-chain, lisk, celo, arbitrum-one, polygon, starknet, tron]
           description: Blockchain network identifier (lowercase in URL).
         - in: path
           name: from

--- a/protocol-overview.mdx
+++ b/protocol-overview.mdx
@@ -32,7 +32,7 @@ The Paycrest protocol consists of several key components working together:
 
 ### 1. Gateway Smart Contract
 
-The core multi-chain contract deployed on supported networks (EVM L2s such as Base, Arbitrum, and Lisk, plus Starknet). It manages:
+The core multi-chain contract deployed on supported networks (EVM L2s such as Base, Arbitrum, and Lisk, plus Starknet and Tron). It manages:
 
 - **Order creation** and validation
 - **Token escrow** and conditional settlement
@@ -171,7 +171,7 @@ A KYB-verified entity that coordinates the entire order routing process:
 
 ## Multi-Chain Support
 
-Paycrest is live on **8 EVM-compatible networks** plus **Starknet**:
+Paycrest is live on **7 EVM-compatible networks** plus **Starknet** and **Tron**:
 
 - **Ethereum**
 - **Base**
@@ -180,10 +180,10 @@ Paycrest is live on **8 EVM-compatible networks** plus **Starknet**:
 - **Arbitrum One**
 - **Lisk**
 - **Celo**
-- **Scroll**
-- **Starknet** (USDT, USDC — use network identifier `starknet`)
+- **Starknet** (USDT, USDC — network identifier `starknet`)
+- **Tron** (USDT — network identifier `tron`)
 
-Additional networks (Tron, Asset Chain, Optimism) have Gateway contracts deployed but aggregator support is pending. See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for the full deployment table.
+Additional networks (Optimism) have Gateway contracts deployed but aggregator support is pending. See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for the full deployment table.
 
 ## Security & Compliance
 

--- a/protocol-overview.mdx
+++ b/protocol-overview.mdx
@@ -32,7 +32,7 @@ The Paycrest protocol consists of several key components working together:
 
 ### 1. Gateway Smart Contract
 
-The core multi-chain contract deployed on fast EVM-compatible networks (e.g., Base, Arbitrum, Lisk). It manages:
+The core multi-chain contract deployed on supported networks (EVM L2s such as Base, Arbitrum, and Lisk, plus Starknet). It manages:
 
 - **Order creation** and validation
 - **Token escrow** and conditional settlement
@@ -171,7 +171,7 @@ A KYB-verified entity that coordinates the entire order routing process:
 
 ## Multi-Chain Support
 
-Paycrest is live on **8 EVM-compatible networks**:
+Paycrest is live on **8 EVM-compatible networks** plus **Starknet**:
 
 - **Ethereum**
 - **Base**
@@ -181,8 +181,9 @@ Paycrest is live on **8 EVM-compatible networks**:
 - **Lisk**
 - **Celo**
 - **Scroll**
+- **Starknet** (USDT, USDC — use network identifier `starknet`)
 
-Additional networks (Starknet, Tron, Asset Chain, Optimism) have Gateway contracts deployed but aggregator support is pending. See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for the full deployment table.
+Additional networks (Tron, Asset Chain, Optimism) have Gateway contracts deployed but aggregator support is pending. See [Gateway Contract Addresses](/resources/gateway-contract-addresses) for the full deployment table.
 
 ## Security & Compliance
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -9,14 +9,23 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ## Q2 2026
 
-### Starknet network support (July 2026)
+### Starknet and Tron network support (July 2026)
 
-Starknet (chain ID `SN_MAIN`) is now fully supported by the aggregator. Gateway contract: `0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583`.
+**Starknet** (chain ID `23448594291968334`) and **Tron** (chain ID `728126428`) are fully supported by the aggregator.
 
-- **Network identifier:** `starknet` on create-order, rates, and token list responses
-- **Tokens:** USDT and USDC (6 decimals)
-- **Addresses:** use Starknet felt hex (`0x` + 63–64 hex characters) for `refundAddress` and crypto recipient `address` — not EVM checksum addresses
-- **Integration path:** prefer the [Sender API](/implementation-guides/sender-api-integration); see [Gateway Contract Addresses](/resources/gateway-contract-addresses) and [Supported Stablecoins](/resources/supported-stablecoins)
+**Starknet**
+- Gateway: `0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583`
+- Network identifier: `starknet`
+- Tokens: USDT and USDC (6 decimals)
+- Addresses: felt hex (`0x` + 63–64 hex characters)
+
+**Tron**
+- Gateway: `THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU`
+- Network identifier: `tron`
+- Tokens: USDT (6 decimals; contract `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`)
+- Addresses: Base58Check starting with `T`
+
+**Docs cleanup:** Scroll and Asset Chain are no longer listed as supported networks. Prefer the [Sender API](/implementation-guides/sender-api-integration) for Starknet and Tron orders; see [Gateway Contract Addresses](/resources/gateway-contract-addresses) and [Supported Stablecoins](/resources/supported-stablecoins).
 
 ---
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -9,6 +9,17 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ## Q2 2026
 
+### Starknet network support (July 2026)
+
+Starknet (chain ID `SN_MAIN`) is now fully supported by the aggregator. Gateway contract: `0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583`.
+
+- **Network identifier:** `starknet` on create-order, rates, and token list responses
+- **Tokens:** USDT and USDC (6 decimals)
+- **Addresses:** use Starknet felt hex (`0x` + 63–64 hex characters) for `refundAddress` and crypto recipient `address` — not EVM checksum addresses
+- **Integration path:** prefer the [Sender API](/implementation-guides/sender-api-integration); see [Gateway Contract Addresses](/resources/gateway-contract-addresses) and [Supported Stablecoins](/resources/supported-stablecoins)
+
+---
+
 ### Public markets orderbook & provider rate position (June 2026)
 
 **New:** `GET /v2/markets` — unauthenticated public endpoint returning the live protocol orderbook and network-wide aggregate statistics. No API key required; CORS open; ~10 s cache; per-IP rate limited.

--- a/resources/gateway-contract-addresses.mdx
+++ b/resources/gateway-contract-addresses.mdx
@@ -3,7 +3,7 @@ title: "Gateway Contract Addresses"
 description: "Deployment addresses for Paycrest Gateway contracts across all supported networks"
 ---
 
-Paycrest Gateway contracts are deployed across multiple networks (EVM-compatible chains and Starknet). The table below shows all current deployments, including networks that may not yet be fully supported by the aggregator.
+Paycrest Gateway contracts are deployed across multiple networks (EVM-compatible chains, Starknet, and Tron). The table below shows all current deployments, including networks that may not yet be fully supported by the aggregator.
 
 <Note>
   Networks marked as "Coming Soon" have contracts deployed but aggregator support is pending.
@@ -20,11 +20,9 @@ Paycrest Gateway contracts are deployed across multiple networks (EVM-compatible
 | **Arbitrum One** | 42161 | `0xE8bc3B607CfE68F47000E3d200310D49041148Fc` | ✅ Live |
 | **Lisk** | 1135 | `0xff0E00E0110C1FBb5315D276243497b66D3a4d8a` | ✅ Live |
 | **Celo** | 42220 | `0xF418217E3f81092eF44b81C5C8336e6A6fDB0E4b` | ✅ Live |
-| **Scroll** | 534352 | `0x663C5BfE7d44bA946C2dd4b2D1Cf9580319F9338` | ✅ Live |
-| **Starknet** | SN_MAIN | `0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583` | ✅ Live |
-| **Asset Chain** | 42420 | `0xff0E00E0110C1FBb5315D276243497b66D3a4d8a` | 🚧 Coming Soon |
+| **Starknet** | 23448594291968334 | `0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583` | ✅ Live |
+| **Tron** | 728126428 | `THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU` | ✅ Live |
 | **Optimism** | 10 | `0xD293fCd3dBc025603911853d893A4724CF9f70a0` | 🚧 Coming Soon |
-| **Tron** | 728126428 | `THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU` | 🚧 Coming Soon |
 
 ## Network Status Legend
 
@@ -42,11 +40,9 @@ All Gateway contracts are verified on their respective network block explorers:
 - **Arbitrum One**: [Arbiscan](https://arbiscan.io/address/0xE8bc3B607CfE68F47000E3d200310D49041148Fc)
 - **Lisk**: [Lisk Explorer](https://explorer.lisk.com/address/0xff0E00E0110C1FBb5315D276243497b66D3a4d8a)
 - **Celo**: [Celo Explorer](https://explorer.celo.org/address/0xF418217E3f81092eF44b81C5C8336e6A6fDB0E4b)
-- **Scroll**: [Scrollscan](https://scrollscan.com/address/0x663C5BfE7d44bA946C2dd4b2D1Cf9580319F9338)
 - **Starknet**: [Voyager](https://voyager.online/contract/0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583)
-- **Asset Chain**: [Asset Chain Explorer](https://explorer.assetchain.org/address/0xff0E00E0110C1FBb5315D276243497b66D3a4d8a)
-- **Optimism**: [Optimistic Etherscan](https://optimistic.etherscan.io/address/0xD293fCd3dBc025603911853d893A4724CF9f70a0)
 - **Tron**: [Tronscan](https://tronscan.org/#/address/THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU)
+- **Optimism**: [Optimistic Etherscan](https://optimistic.etherscan.io/address/0xD293fCd3dBc025603911853d893A4724CF9f70a0)
 
 ## Integration
 
@@ -68,12 +64,17 @@ const gateway = getContract({
 });
 ```
 
-### Starknet
+### Starknet and Tron
 
-Starknet is fully supported via the Sender API (`network: "starknet"`). Use a valid Starknet wallet address (`0x` followed by 63–64 hex characters; not the zero address) for `refundAddress` / recipient `address`. Prefer the [Sender API Integration](/implementation-guides/sender-api-integration) path for order creation; the [Smart Contract Interaction](/implementation-guides/smart-contract-interaction) guide covers EVM Gateway calls.
+Starknet and Tron are fully supported via the Sender API (`network: "starknet"` or `network: "tron"`).
+
+- **Starknet addresses:** felt hex (`0x` + 63–64 hex characters; not the zero address)
+- **Tron addresses:** Base58Check starting with `T` (not EVM `0x` addresses)
+
+Prefer the [Sender API Integration](/implementation-guides/sender-api-integration) path for order creation on these networks; the [Smart Contract Interaction](/implementation-guides/smart-contract-interaction) guide covers EVM Gateway calls.
 
 For detailed integration guides, see:
-- **[Sender API Integration](/implementation-guides/sender-api-integration)** — API-based integration (recommended for Starknet)
+- **[Sender API Integration](/implementation-guides/sender-api-integration)** — API-based integration (recommended for Starknet and Tron)
 - **[Smart Contract Interaction](/implementation-guides/smart-contract-interaction)** — Direct EVM contract integration
 
 <Note>

--- a/resources/gateway-contract-addresses.mdx
+++ b/resources/gateway-contract-addresses.mdx
@@ -3,7 +3,7 @@ title: "Gateway Contract Addresses"
 description: "Deployment addresses for Paycrest Gateway contracts across all supported networks"
 ---
 
-Paycrest Gateway contracts are deployed across multiple EVM-compatible networks. The table below shows all current deployments, including networks that may not yet be fully supported by the aggregator.
+Paycrest Gateway contracts are deployed across multiple networks (EVM-compatible chains and Starknet). The table below shows all current deployments, including networks that may not yet be fully supported by the aggregator.
 
 <Note>
   Networks marked as "Coming Soon" have contracts deployed but aggregator support is pending.
@@ -21,9 +21,9 @@ Paycrest Gateway contracts are deployed across multiple EVM-compatible networks.
 | **Lisk** | 1135 | `0xff0E00E0110C1FBb5315D276243497b66D3a4d8a` | ✅ Live |
 | **Celo** | 42220 | `0xF418217E3f81092eF44b81C5C8336e6A6fDB0E4b` | ✅ Live |
 | **Scroll** | 534352 | `0x663C5BfE7d44bA946C2dd4b2D1Cf9580319F9338` | ✅ Live |
+| **Starknet** | SN_MAIN | `0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583` | ✅ Live |
 | **Asset Chain** | 42420 | `0xff0E00E0110C1FBb5315D276243497b66D3a4d8a` | 🚧 Coming Soon |
 | **Optimism** | 10 | `0xD293fCd3dBc025603911853d893A4724CF9f70a0` | 🚧 Coming Soon |
-| **Starknet** | — | TBA | 🚧 Coming Soon |
 | **Tron** | 728126428 | `THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU` | 🚧 Coming Soon |
 
 ## Network Status Legend
@@ -43,13 +43,16 @@ All Gateway contracts are verified on their respective network block explorers:
 - **Lisk**: [Lisk Explorer](https://explorer.lisk.com/address/0xff0E00E0110C1FBb5315D276243497b66D3a4d8a)
 - **Celo**: [Celo Explorer](https://explorer.celo.org/address/0xF418217E3f81092eF44b81C5C8336e6A6fDB0E4b)
 - **Scroll**: [Scrollscan](https://scrollscan.com/address/0x663C5BfE7d44bA946C2dd4b2D1Cf9580319F9338)
+- **Starknet**: [Voyager](https://voyager.online/contract/0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583)
 - **Asset Chain**: [Asset Chain Explorer](https://explorer.assetchain.org/address/0xff0E00E0110C1FBb5315D276243497b66D3a4d8a)
 - **Optimism**: [Optimistic Etherscan](https://optimistic.etherscan.io/address/0xD293fCd3dBc025603911853d893A4724CF9f70a0)
 - **Tron**: [Tronscan](https://tronscan.org/#/address/THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU)
 
 ## Integration
 
-To integrate with the Gateway contract directly, use the address for your target network:
+### EVM networks
+
+To integrate with the Gateway contract directly on an EVM network, use the address for your target chain:
 
 ```javascript
 import { getContract } from "viem";
@@ -65,9 +68,13 @@ const gateway = getContract({
 });
 ```
 
+### Starknet
+
+Starknet is fully supported via the Sender API (`network: "starknet"`). Use a valid Starknet wallet address (`0x` followed by 63–64 hex characters; not the zero address) for `refundAddress` / recipient `address`. Prefer the [Sender API Integration](/implementation-guides/sender-api-integration) path for order creation; the [Smart Contract Interaction](/implementation-guides/smart-contract-interaction) guide covers EVM Gateway calls.
+
 For detailed integration guides, see:
-- **[Smart Contract Interaction](/implementation-guides/smart-contract-interaction)** — Direct contract integration
-- **[Sender API Integration](/implementation-guides/sender-api-integration)** — API-based integration
+- **[Sender API Integration](/implementation-guides/sender-api-integration)** — API-based integration (recommended for Starknet)
+- **[Smart Contract Interaction](/implementation-guides/smart-contract-interaction)** — Direct EVM contract integration
 
 <Note>
   Contract addresses vary by network. Always use the correct address for your target network and verify it on the block explorer before use. Check our [contracts repository](https://github.com/paycrest/contracts) for the latest deployment information.

--- a/resources/supported-stablecoins.mdx
+++ b/resources/supported-stablecoins.mdx
@@ -3,23 +3,23 @@ title: "Supported Stablecoins"
 description: "Complete list of supported stablecoins and their network availability"
 ---
 
-Paycrest supports three stablecoins across eight blockchain networks. Use the [GET /tokens](/api-reference/general/list-supported-tokens) endpoint for the live list including contract addresses, decimals, and network availability.
+Paycrest supports three stablecoins across nine blockchain networks (eight EVM chains plus Starknet). Use the [GET /tokens](/api-reference/general/list-supported-tokens) endpoint for the live list including contract addresses, decimals, and network availability.
 
 ## Stablecoin Overview
 
 | Stablecoin | Networks | Base Currency | Notes |
 |------------|----------|--------------|-------|
-| **USDT** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Scroll | USD | Most widely supported |
-| **USDC** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Scroll | USD | Regulated, high security standards |
+| **USDT** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Scroll, Starknet | USD | Most widely supported |
+| **USDC** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Scroll, Starknet | USD | Regulated, high security standards |
 | **cNGN** | Ethereum, Base, Polygon, BNB Smart Chain | NGN | Stablecoin pegged to the Nigerian Naira |
 
 ## Support Matrix
 
-| Stablecoin | Ethereum | Base | Arbitrum One | Polygon | BNB Smart Chain | Lisk | Celo | Scroll |
-|------------|----------|------|--------------|---------|-----------------|------|------|--------|
-| **USDT** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **USDC** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **cNGN** | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Stablecoin | Ethereum | Base | Arbitrum One | Polygon | BNB Smart Chain | Lisk | Celo | Scroll | Starknet |
+|------------|----------|------|--------------|---------|-----------------|------|------|--------|----------|
+| **USDT** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **USDC** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **cNGN** | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 ## Contract Addresses
 
@@ -39,6 +39,7 @@ Paycrest supports three stablecoins across eight blockchain networks. Use the [G
 | Lisk | `0x05D032ac25d322df992303dCa074EE7392C117b9` | 6 |
 | Celo | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | 6 |
 | Scroll | `0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df` | 6 |
+| Starknet | `0x068F5c6a61780768455de69077E07e89787839bf8166dEcfBf92B645209c0fB8` | 6 |
 
 ### USDC
 
@@ -52,6 +53,7 @@ Paycrest supports three stablecoins across eight blockchain networks. Use the [G
 | Lisk | `0xF242275d3a6527d877f2c927a82D9b057609cc71` | 6 |
 | Celo | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | 6 |
 | Scroll | `0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4` | 6 |
+| Starknet | `0x033068F6539f8e6e6b131e6B2B814e6c34A5224bC66947c47DaB9dFeE93b35fb` | 6 |
 
 ### cNGN
 
@@ -64,7 +66,7 @@ Paycrest supports three stablecoins across eight blockchain networks. Use the [G
 
 ## Network Configuration
 
-When creating orders, specify the stablecoin and network using the `token` and `network` parameters (v1) or via the `source`/`destination` objects (v2):
+When creating orders, specify the stablecoin and network using the `token` and `network` parameters (v1) or via the `source`/`destination` objects (v2). Use **`starknet`** as the network identifier for Starknet.
 
 <Tabs>
   <Tab title="v2 API (recommended)">
@@ -77,6 +79,31 @@ const order = {
     currency: "USDT",
     network: "base",
     refundAddress: "0xYourAddress"
+  },
+  destination: {
+    type: "fiat",
+    currency: "NGN",
+    recipient: {
+      institution: "GTBINGLA",
+      accountIdentifier: "1234567890",
+      accountName: "John Doe",
+      memo: "Payment"
+    }
+  }
+};
+```
+  </Tab>
+  <Tab title="v2 Starknet offramp">
+```javascript
+// Offramp: USDT on Starknet → NGN bank account
+// refundAddress must be a Starknet address (0x + 63–64 hex chars)
+const order = {
+  amount: "100",
+  source: {
+    type: "crypto",
+    currency: "USDT",
+    network: "starknet",
+    refundAddress: "0x046a056257607e1126a73b789bc6b56216e260261d4b54dd0809df46638bcbad"
   },
   destination: {
     type: "fiat",
@@ -110,6 +137,10 @@ const order = {
 ```
   </Tab>
 </Tabs>
+
+<Note>
+  **Starknet addresses** are felt-sized hex strings (`0x` + 63–64 hex digits). Do not use EVM checksum formatting. The zero address is rejected. Pad shorter hex values to 64 digits when normalizing for wallets or explorers.
+</Note>
 
 ## API Endpoints
 

--- a/resources/supported-stablecoins.mdx
+++ b/resources/supported-stablecoins.mdx
@@ -3,22 +3,22 @@ title: "Supported Stablecoins"
 description: "Complete list of supported stablecoins and their network availability"
 ---
 
-Paycrest supports three stablecoins across nine blockchain networks (eight EVM chains plus Starknet). Use the [GET /tokens](/api-reference/general/list-supported-tokens) endpoint for the live list including contract addresses, decimals, and network availability.
+Paycrest supports three stablecoins across nine blockchain networks (seven EVM chains plus Starknet and Tron). Use the [GET /tokens](/api-reference/general/list-supported-tokens) endpoint for the live list including contract addresses, decimals, and network availability.
 
 ## Stablecoin Overview
 
 | Stablecoin | Networks | Base Currency | Notes |
 |------------|----------|--------------|-------|
-| **USDT** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Scroll, Starknet | USD | Most widely supported |
-| **USDC** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Scroll, Starknet | USD | Regulated, high security standards |
+| **USDT** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Starknet, Tron | USD | Most widely supported |
+| **USDC** | Ethereum, Base, Arbitrum One, Polygon, BNB Smart Chain, Lisk, Celo, Starknet | USD | Regulated, high security standards |
 | **cNGN** | Ethereum, Base, Polygon, BNB Smart Chain | NGN | Stablecoin pegged to the Nigerian Naira |
 
 ## Support Matrix
 
-| Stablecoin | Ethereum | Base | Arbitrum One | Polygon | BNB Smart Chain | Lisk | Celo | Scroll | Starknet |
-|------------|----------|------|--------------|---------|-----------------|------|------|--------|----------|
+| Stablecoin | Ethereum | Base | Arbitrum One | Polygon | BNB Smart Chain | Lisk | Celo | Starknet | Tron |
+|------------|----------|------|--------------|---------|-----------------|------|------|----------|------|
 | **USDT** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **USDC** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **USDC** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **cNGN** | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 ## Contract Addresses
@@ -38,8 +38,8 @@ Paycrest supports three stablecoins across nine blockchain networks (eight EVM c
 | BNB Smart Chain | `0x55d398326f99059fF775485246999027B3197955` | **18** |
 | Lisk | `0x05D032ac25d322df992303dCa074EE7392C117b9` | 6 |
 | Celo | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | 6 |
-| Scroll | `0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df` | 6 |
 | Starknet | `0x068F5c6a61780768455de69077E07e89787839bf8166dEcfBf92B645209c0fB8` | 6 |
+| Tron | `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` | 6 |
 
 ### USDC
 
@@ -52,7 +52,6 @@ Paycrest supports three stablecoins across nine blockchain networks (eight EVM c
 | BNB Smart Chain | `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d` | **18** |
 | Lisk | `0xF242275d3a6527d877f2c927a82D9b057609cc71` | 6 |
 | Celo | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | 6 |
-| Scroll | `0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4` | 6 |
 | Starknet | `0x033068F6539f8e6e6b131e6B2B814e6c34A5224bC66947c47DaB9dFeE93b35fb` | 6 |
 
 ### cNGN
@@ -66,7 +65,7 @@ Paycrest supports three stablecoins across nine blockchain networks (eight EVM c
 
 ## Network Configuration
 
-When creating orders, specify the stablecoin and network using the `token` and `network` parameters (v1) or via the `source`/`destination` objects (v2). Use **`starknet`** as the network identifier for Starknet.
+When creating orders, specify the stablecoin and network using the `token` and `network` parameters (v1) or via the `source`/`destination` objects (v2). Use **`starknet`** for Starknet and **`tron`** for Tron.
 
 <Tabs>
   <Tab title="v2 API (recommended)">
@@ -118,6 +117,31 @@ const order = {
 };
 ```
   </Tab>
+  <Tab title="v2 Tron offramp">
+```javascript
+// Offramp: USDT on Tron → NGN bank account
+// refundAddress must be a Tron Base58 address (starts with T)
+const order = {
+  amount: "100",
+  source: {
+    type: "crypto",
+    currency: "USDT",
+    network: "tron",
+    refundAddress: "TYourTronWalletAddress............."
+  },
+  destination: {
+    type: "fiat",
+    currency: "NGN",
+    recipient: {
+      institution: "GTBINGLA",
+      accountIdentifier: "1234567890",
+      accountName: "John Doe",
+      memo: "Payment"
+    }
+  }
+};
+```
+  </Tab>
   <Tab title="v1 API (legacy)">
 ```javascript
 // Offramp only: USDC on Base → NGN bank account
@@ -139,7 +163,9 @@ const order = {
 </Tabs>
 
 <Note>
-  **Starknet addresses** are felt-sized hex strings (`0x` + 63–64 hex digits). Do not use EVM checksum formatting. The zero address is rejected. Pad shorter hex values to 64 digits when normalizing for wallets or explorers.
+  **Starknet addresses** are felt-sized hex strings (`0x` + 63–64 hex digits). Do not use EVM checksum formatting. The zero address is rejected.
+
+  **Tron addresses** are Base58Check and start with `T`. Do not pass EVM `0x` addresses when `network` is `tron`.
 </Note>
 
 ## API Endpoints

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -33,6 +33,7 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
       <li><strong>Unsupported token</strong>: Check supported tokens in the resources section</li>
       <li><strong>Invalid network</strong>: Ensure the network supports your chosen token</li>
       <li><strong>Invalid Starknet address</strong>: For `network: "starknet"`, use felt hex (`0x` + 63–64 hex digits), not an EVM checksum address</li>
+      <li><strong>Invalid Tron address</strong>: For `network: "tron"`, use a Base58 address starting with `T`, not an EVM `0x` address</li>
       <li><strong>Missing recipient details</strong>: All recipient fields are required</li>
       <li><strong>Invalid institution</strong>: Check supported institutions for the currency</li>
     </ul>
@@ -179,8 +180,8 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
         <ul>
           <li>Ethereum</li>
           <li>BNB Smart Chain</li>
-          <li>Scroll</li>
           <li>Starknet</li>
+          <li>Tron</li>
         </ul>
       </Card>
     </CardGroup>

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -32,6 +32,7 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
       <li><strong>Invalid amount</strong>: Amount must be a positive number</li>
       <li><strong>Unsupported token</strong>: Check supported tokens in the resources section</li>
       <li><strong>Invalid network</strong>: Ensure the network supports your chosen token</li>
+      <li><strong>Invalid Starknet address</strong>: For `network: "starknet"`, use felt hex (`0x` + 63–64 hex digits), not an EVM checksum address</li>
       <li><strong>Missing recipient details</strong>: All recipient fields are required</li>
       <li><strong>Invalid institution</strong>: Check supported institutions for the currency</li>
     </ul>
@@ -179,6 +180,7 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
           <li>Ethereum</li>
           <li>BNB Smart Chain</li>
           <li>Scroll</li>
+          <li>Starknet</li>
         </ul>
       </Card>
     </CardGroup>


### PR DESCRIPTION
### Description

With Starknet live in Paycrest routing, the docs still marked it as Coming Soon / TBA. This PR brings official docs in line so developers can configure and accept Starknet payments without address/network mistakes.

**What changed**
- Marked Starknet as a supported network in introduction, protocol overview, and architecture (network id `starknet`, chain `SN_MAIN`).
- Updated Gateway Contract Addresses: live gateway `0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583` + Voyager link.
- Added Starknet USDT/USDC to Supported Stablecoins (matrix + contract addresses) and a v2 offramp example.
- Added `starknet` to OpenAPI v1/v2 network enums.
- Sender API: Starknet address rules + dedicated offramp curl example; provider setup and troubleshooting tips for Starknet wallets.
- Smart Contract Interaction: note that EVM examples apply to EVM only; Starknet via Sender API.
- Changelog: Starknet network support (July 2026).

No API/contract code changes — documentation only.

### References

- Closes #18 

### Testing

- Preview with Mintlify locally (`mintlify dev`) and spot-check:
  - Gateway addresses table shows Starknet ✅ Live
  - Supported Stablecoins lists Starknet USDT/USDC
  - Sender API “Offramp (Starknet)” example and address note
  - OpenAPI network enums include `starknet`
  - Changelog entry renders under Q2 2026
- Cross-checked network id and token contracts against live `GET /v2/tokens`

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed/fixed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).