### PR TITLE
docs(sender): document optional senderFeeAddress on V2 create order

### DIFF
--- a/concepts/participants.mdx
+++ b/concepts/participants.mdx
@@ -32,7 +32,7 @@ A **KYB-verified entity** that initiates either a fiat-to-stablecoin or stableco
 - **E-commerce**: Accept crypto payments and settle in fiat
 
 <Note>
-  **Sender Fee Model:** Sender businesses can optionally charge fees to their users. Configure a fixed fee via the dashboard, or pass `senderFeePercent` on each order request (overrides the dashboard setting). The fee is settled atomically onchain upon successful order settlement, with no offchain billing required.
+  **Sender Fee Model:** Sender businesses can optionally charge fees to their users. Configure a default fee via the dashboard, or pass `senderFee` / `senderFeePercent` on each V2 order request. When the effective fee is greater than zero, a fee recipient is required — either configured on the profile or passed as `senderFeeAddress` on the request. The fee is settled atomically onchain upon successful order settlement, with no offchain billing required.
 </Note>
 
 ## Recipient

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -283,7 +283,9 @@ order = requests.post(
 | `amount` | string | ✅ | Payment amount. Denomination set by `amountIn` (defaults to crypto units). |
 | `amountIn` | string | — | `"crypto"` (default) or `"fiat"`. Set to `"fiat"` when `amount` is in the fiat currency. |
 | `rate` | string | — | Exchange rate (fiat per crypto). **Omit** to let the API choose a valid rate. Pass **`rate`** only when you lock a quote from the user; it must stay within market tolerance. See [Prefetch a quote for the UI](#prefetch-a-quote-for-the-ui) if you display rates before create. |
-| `senderFeePercent` | string | — | Optional fee percentage you collect, settled atomically onchain. |
+| `senderFee` | string | — | Optional fixed fee in crypto units. Mutually exclusive with `senderFeePercent`. |
+| `senderFeePercent` | string | — | Optional fee percentage you collect, settled atomically onchain. Mutually exclusive with `senderFee`. |
+| `senderFeeAddress` | string | Conditionally | Fee recipient address. **Required when the effective sender fee is greater than zero** and no fee address is configured on the sender profile. Not required when fee is zero. |
 | `reference` | string | — | Your internal order ID. |
 | `source` | object | ✅ | `{ type: "crypto", ... }` for offramp; `{ type: "fiat", ... }` for onramp. |
 | `destination` | object | ✅ | `{ type: "fiat", ... }` for offramp; `{ type: "crypto", ... }` for onramp. |
@@ -658,13 +660,76 @@ buy_rate = (data.get("buy") or {}).get("rate")
 
 ## Sender Fees
 
-You can optionally charge your users a fee on each order. It's settled atomically onchain — no offchain billing required. Configure your fee in [Sender Dashboard](https://app.paycrest.io) settings (required). You can override it per-request by passing `senderFeePercent` in the order payload.
+You can optionally charge your users a fee on each order. It's settled atomically onchain — no offchain billing required.
+
+You can configure a default fee in [Sender Dashboard](https://app.paycrest.io) settings, or pass a per-request fee via `senderFee` (fixed amount) or `senderFeePercent`. Do not send both `senderFee` and `senderFeePercent` on the same request.
+
+**Fee address rule:** when the effective sender fee is greater than zero (from the request or a profile-configured fee), a fee recipient address is **required** — either configured on the sender profile for that token, or passed as `senderFeeAddress` on the create payload. When the effective fee is zero, `senderFeeAddress` is not required.
+
+**Example — with sender fee (fee address required):**
 
 ```json
 {
   "amount": "100",
-  "senderFeePercent": "0.5",
+  "amountIn": "fiat",
+  "senderFeePercent": "1",
+  "senderFeeAddress": "0xYourFeeRecipientAddress",
+  "reference": "order-ref-001",
+  "source": {
+    "type": "fiat",
+    "currency": "NGN",
+    "refundAccount": {
+      "institution": "MOMONGPC",
+      "accountIdentifier": "1234567890",
+      "accountName": "John Doe"
+    }
+  },
+  "destination": {
+    "type": "crypto",
+    "currency": "USDC",
+    "recipient": {
+      "address": "0xRecipientWalletAddress",
+      "network": "base"
+    }
+  }
+}
+```
+
+Fixed fee alternative:
+
+```json
+{
+  "amount": "100",
+  "senderFee": "0.5",
+  "senderFeeAddress": "0xYourFeeRecipientAddress",
   ...
+}
+```
+
+**Example — no sender fee (fee address not required):**
+
+```json
+{
+  "amount": "100",
+  "amountIn": "fiat",
+  "reference": "order-ref-002",
+  "source": {
+    "type": "fiat",
+    "currency": "NGN",
+    "refundAccount": {
+      "institution": "MOMONGPC",
+      "accountIdentifier": "1234567890",
+      "accountName": "John Doe"
+    }
+  },
+  "destination": {
+    "type": "crypto",
+    "currency": "USDC",
+    "recipient": {
+      "address": "0xRecipientWalletAddress",
+      "network": "base"
+    }
+  }
 }
 ```
 
@@ -719,7 +784,7 @@ The response includes `receiveAddress` (string) and `validUntil`. Send tokens to
 | Schema | Flat: `token`, `network`, `recipient` | Polymorphic: `source`, `destination` with `type` |
 | `refundAddress` | `returnAddress` (top-level) | `source.refundAddress` (offramp); onramp uses `source.refundAccount` |
 | Amount direction | Always crypto | `amountIn: "fiat"` or `"crypto"` |
-| Sender fee | Fixed via dashboard | Dashboard (fixed) **or** `senderFeePercent` on request |
+| Sender fee | Fixed via dashboard (fee + refund addresses required on profile) | Optional; `senderFee` / `senderFeePercent` on request. If fee > 0, `senderFeeAddress` (or profile fee address) is required |
 | Numeric types | Number | String |
 | Webhook version | `"1"` | `"2"` |
 

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -754,10 +754,20 @@ components:
           description: Quoted exchange rate (fiat per crypto unit). Optional — protocol uses best available rate if omitted.
         senderFee:
           type: string
-          description: Fixed sender fee in crypto units.
+          description: Fixed sender fee in crypto units. Mutually exclusive with `senderFeePercent`. When the effective sender fee is greater than zero, `senderFeeAddress` (or a fee address configured on the sender profile) is required.
+          example: "0.5"
         senderFeePercent:
           type: string
-          description: Sender fee as a percentage of the order amount (alternative to senderFee).
+          description: Sender fee as a percentage of the order amount (alternative to `senderFee`). Mutually exclusive with `senderFee`. When the effective sender fee is greater than zero, `senderFeeAddress` (or a fee address configured on the sender profile) is required.
+          example: "1"
+        senderFeeAddress:
+          type: string
+          description: |
+            Optional fee recipient address for this order. Required when the effective sender fee is greater than zero
+            (from `senderFee`, `senderFeePercent`, or a profile-configured fee) and no fee address is configured on the
+            sender profile for the token. Not required when the effective fee is zero. Must be a valid address for the
+            order's crypto network (EVM, Tron, or Starknet).
+          example: "0xYourFeeRecipientAddress"
         reference:
           type: string
           description: Your internal reference ID for this order.

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -9,6 +9,21 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ## Q3 2026
 
+### Optional `senderFeeAddress` on V2 create order (July 2026)
+
+**Updated:** `POST /v2/sender/orders` accepts an optional top-level **`senderFeeAddress`**.
+
+| Effective sender fee | `senderFeeAddress` |
+|----------------------|--------------------|
+| Greater than zero (from `senderFee`, `senderFeePercent`, or a profile-configured fee) | **Required** — pass it on the request, or configure a fee address on the sender profile for that token |
+| Zero | **Not required** |
+
+`senderFee` and `senderFeePercent` remain mutually exclusive. Applies to both offramp and onramp. V1 create order is unchanged (still requires fee and refund addresses on the sender profile).
+
+See [Sender API Integration — Sender Fees](/implementation-guides/sender-api-integration#sender-fees) and [Initiate Order](/api-reference/sender/initiate-payment-order-v2).
+
+---
+
 ### Markets orderbook query filters (July 2026)
 
 **Updated:** `GET /v2/markets` accepts optional query filters to narrow the returned orderbook:
@@ -146,7 +161,7 @@ The v2 API introduces a unified endpoint for both offramp and onramp flows, repl
 | Direction support | Offramp only | Offramp + onramp |
 | Request schema | Flat: `token`, `network`, `recipient` | Polymorphic: `source`, `destination` with `type` discriminator |
 | Amount direction | Always crypto | `amountIn: "fiat"` or `"crypto"` |
-| Sender fee | Fixed amount via dashboard | Dashboard required; `senderFeePercent` on request overrides it |
+| Sender fee | Fixed amount via dashboard | Optional; `senderFee` / `senderFeePercent` on request. If fee > 0, `senderFeeAddress` (or profile fee address) is required |
 | Numeric field types | `decimal.Decimal` | `string` |
 | Webhook version | `webhookVersion: "1"` | `webhookVersion: "2"` |
 


### PR DESCRIPTION
### Description

Documents the optional `senderFeeAddress` field on V2 `POST /v2/sender/orders`, aligned with aggregator PR #972.

**What changed for integrators**

- When the effective sender fee is greater than zero (`senderFee`, `senderFeePercent`, or a profile-configured fee), a fee recipient address is required — either configured on the sender profile or passed as `senderFeeAddress` on the create payload.
- When the effective fee is zero, `senderFeeAddress` is not required.
- `senderFee` and `senderFeePercent` remain mutually exclusive.

**Docs updated**

- `openapi-v2.yaml` — add `senderFeeAddress`; clarify fee field descriptions (API reference page pulls from this)
- `implementation-guides/sender-api-integration.mdx` — request fields table, Sender Fees section with onramp examples, v1 vs v2 table
- `resources/changelog.mdx` — Q3 2026 entry; correct historical v2 sender-fee row
- `concepts/participants.mdx` — sender fee model note

No breaking API or contract changes; documentation only.

### References

- Aggregator: https://github.com/paycrest/aggregator/pull/972
- Jira: KAN-728

### Testing

- Review OpenAPI `V2PaymentOrderPayload` and MDX examples against aggregator `resolveV2SenderFee` behavior
- Confirm Mintlify preview renders Initiate Order (v2) params and Sender Fees section with examples
- No automated tests (docs-only change)

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
