### PR TITLE
docs(smart-contract-interaction): add onchain attribution via ERC-8021

### DIFF
--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -811,7 +811,7 @@ Fixed fee alternative:
 
 ## Onchain attribution
 
-On EVM networks, the aggregator tags the transactions it submits on your behalf (create, settle, and refund) with an [ERC-8021](https://eip.tools/eip/8021) data suffix carrying the **trading name** from your KYB profile. It makes your orders publicly attributable to your business onchain.
+On EVM networks, the aggregator tags the transactions it submits for your orders (creation, settlement, and refunds) with an [ERC-8021](https://eip.tools/eip/8021) data suffix carrying the **trading name** from your KYB profile. It makes your orders publicly attributable to your business onchain.
 
 - **Automatic.** There is nothing to configure or send. Senders with no trading name on file simply get no suffix.
 - **EVM only.** Starknet and Tron transactions carry no suffix.

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -809,6 +809,18 @@ Fixed fee alternative:
 
 ---
 
+## Onchain attribution
+
+On EVM networks, the aggregator tags the transactions it submits on your behalf (create, settle, and refund) with an [ERC-8021](https://eip.tools/eip/8021) data suffix carrying the **trading name** from your KYB profile. It makes your orders publicly attributable to your business onchain.
+
+- **Automatic.** There is nothing to configure or send. Senders with no trading name on file simply get no suffix.
+- **EVM only.** Starknet and Tron transactions carry no suffix.
+- **Display only.** The suffix does not affect order processing, sender resolution, or webhooks, and it is not read back by the aggregator. It costs roughly 16 gas per non-zero byte.
+
+If you call the Gateway contract directly instead of using this API, see [Onchain Attribution (ERC-8021)](/implementation-guides/smart-contract-interaction#onchain-attribution-erc-8021) for appending your own suffix.
+
+---
+
 ## Testing
 
 Paycrest runs on mainnet only. Test with the minimum order size: **$0.50 on any supported chain**. Use small amounts until you've verified your integration end-to-end.

--- a/implementation-guides/smart-contract-interaction.mdx
+++ b/implementation-guides/smart-contract-interaction.mdx
@@ -591,25 +591,37 @@ curl -X GET "https://api.paycrest.io/v2/pubkey"
 
 ## Onchain Attribution (ERC-8021)
 
-On EVM networks you can attribute your `createOrder` transactions onchain by appending an [ERC-8021](https://eip.tools/eip/8021) data suffix to the transaction calldata. The suffix carries your **trading name** as a public, human-readable attribution tag.
+Paycrest tags EVM transactions with an [ERC-8021](https://eip.tools/eip/8021) schema-0 data suffix that carries a sender's **trading name** as a public, human-readable attribution tag.
 
-The suffix is execution-inert: the Gateway contract ignores trailing bytes beyond its expected ABI arguments, so the suffix passes through without affecting execution. Cost is roughly 16 gas per non-zero byte.
+The suffix is execution-inert: the Gateway contract ignores trailing bytes beyond its expected ABI arguments, so it passes through without affecting execution. Cost is roughly 16 gas per non-zero byte.
 
 <Note>
-  The on-chain suffix is for **public attribution only**. Sender identification for order processing (webhooks, order lookup) continues to use `metadata.apiKey` inside the encrypted `messageHash`. The suffix is a human-readable tag; the encrypted metadata is the authoritative source for sender resolution.
+  **The suffix is public attribution only.** It is not read for sender identification. Sender resolution, webhook delivery, and order lookup use `metadata.apiKey` inside the encrypted `messageHash`, which remains the authoritative and only mechanism.
 </Note>
+
+### Who appends the suffix
+
+| Path | Who appends it | Code used |
+|------|----------------|-----------|
+| **Sender API** (aggregator-relayed orders) | The aggregator, automatically | The sender's KYB trading name |
+| **Direct Gateway integration** (this guide) | You, on your own `createOrder` calldata | Whatever you choose to publish |
+| **Noblocks** on Base mainnet | The Noblocks app | Its registered Base Builder Code |
+
+On the Sender API path the aggregator appends the suffix to the keeper transactions it submits on its native EIP-7702 relayer, covering create, settle, and refund. Senders with no trading name on their KYB profile get no suffix. There is nothing to configure.
+
+If you call the Gateway contract directly, nothing is appended for you. The rest of this section covers appending your own.
 
 ### Your sender code
 
-Your sender code is your **trading name** from your KYB profile — a human-readable business identifier. Find it in the dashboard at [app.paycrest.io](https://app.paycrest.io).
+Pick a printable-ASCII code that identifies you publicly. Paycrest uses the **trading name** from the KYB profile for its own attribution, so matching that keeps your direct transactions consistent with your Sender API ones.
 
 ```javascript
-// Your trading name from KYB profile
+// Your trading name from your KYB profile at app.paycrest.io
 const senderCode = "AcmeCorp";
 ```
 
 <Callout type="warning">
-  The trading name is **public attribution material** and is permanently visible onchain once used. It's a human-readable tag for attribution purposes. Your API **secret** is never placed onchain and remains for webhooks and REST authentication only.
+  Whatever you put in the suffix is **permanently public onchain**. Use a business identifier you are happy to publish. Never place an API secret, key ID, or any credential in the suffix: your API secret stays for webhooks and REST authentication only.
 </Callout>
 
 ### Suffix layout
@@ -623,9 +635,9 @@ Schema 0, parsed **backwards from the end** of the calldata:
 | `schemaId` | 1 byte | `0x00` |
 | `marker` | 16 bytes | `0x8021` repeated 8 times |
 
-Constraints: `codes` must be printable ASCII (`0x20`–`0x7e`) and at most **255 bytes** once joined. Violating either makes the suffix unparseable, and the order silently falls back to `metadata.apiKey` attribution.
+Constraints: `codes` must be non-empty printable ASCII (`0x20` to `0x7e`), individual codes must not contain a comma (the delimiter), and the joined string must be at most **255 bytes**. Violating any of these makes the suffix unparseable by ERC-8021 readers. It has no effect on your order, which is processed from `metadata.apiKey` either way.
 
-**Worked example** for trading name `AcmeCorp` on a non-Base EVM chain:
+**Worked example** for trading name `AcmeCorp`:
 
 ```text
 41636d65436f7270 08 00 80218021802180218021802180218021
@@ -715,7 +727,7 @@ func encodeAttributionSuffix(codes []string) ([]byte, error) {
 
 ### Appending to createOrder
 
-The suffix must be appended to the calldata **before signing and gas estimation** so it is covered by the signature and paid for in the gas limit.
+The suffix must be appended to the calldata **before signing and gas estimation** so it is covered by the signature and paid for in the gas limit. Keep sending `metadata.apiKey`: the suffix is additive, not a replacement.
 
 <Callout type="warning">
   Viem's `writeContract` and `simulate` helpers build calldata internally and give you no place to append raw bytes. To attach a suffix, encode the call yourself with `encodeFunctionData` and send it with `sendTransaction`.
@@ -732,7 +744,7 @@ async function createOffRampOrderAttributed(amount, recipient, refundAddress) {
   const messageHash = await encryptRecipientData({
     ...recipient,
     accountName,
-    // Optional once the onchain suffix is in place; see Precedence below.
+    // Required: this is how the aggregator identifies you. The suffix does not replace it.
     metadata: { apiKey: process.env.PAYCREST_API_KEY },
   });
   await approveUSDT(amount);
@@ -751,7 +763,7 @@ async function createOffRampOrderAttributed(amount, recipient, refundAddress) {
     ],
   });
 
-  const senderCode = "AcmeCorp"; // Your trading name from KYB profile
+  const senderCode = "AcmeCorp"; // Your public attribution code
   const data = concatHex([callData, encodeAttributionSuffix([senderCode])]);
 
   const hash = await walletClient.sendTransaction({
@@ -778,7 +790,7 @@ tx = gateway.functions.createOrder(
     'nonce': w3.eth.get_transaction_count(user_address),
 })
 
-sender_code = "AcmeCorp"  # Your trading name from KYB profile
+sender_code = "AcmeCorp"  # Your public attribution code
 tx['data'] = tx['data'] + encode_attribution_suffix([sender_code]).hex()
 
 # Estimate gas AFTER appending so the suffix is covered.
@@ -799,7 +811,7 @@ if err != nil {
     return err
 }
 
-senderCode := "AcmeCorp" // Your trading name from KYB profile
+senderCode := "AcmeCorp" // Your public attribution code
 suffix, err := encodeAttributionSuffix([]string{senderCode})
 if err != nil {
     return err
@@ -824,50 +836,45 @@ gasLimit, err := client.EstimateGas(ctx, ethereum.CallMsg{
 
 ### Where the suffix must live
 
-The indexer reads the **outer transaction calldata** for the transaction that emitted the `OrderCreated` event, then parses backwards from its final byte.
+ERC-8021 readers parse the **outer transaction calldata** backwards from its final byte, so the suffix has to be the last thing in the top-level input.
 
 - **EOA senders**: append to `tx.data`.
-- **Account abstraction / smart accounts**: append to the **outer** `userOp.callData` — the top-level input that lands onchain.
-- **Do not** bury the suffix inside a nested or inner call. A suffix on an inner call is not visible to the parser, because ABI encoding pads inner `bytes` fields and the outer calldata will not end with the marker.
+- **Account abstraction / smart accounts**: append to the **outer** `userOp.callData`, the top-level input that lands onchain.
+- **Do not** bury the suffix inside a nested or inner call. A suffix on an inner call is invisible to the parser, because ABI encoding pads inner `bytes` fields and the outer calldata will not end with the marker.
 
-Anything that appends bytes after your suffix will also break parsing, since only the trailing suffix is read.
+Anything that appends bytes after your suffix breaks parsing too, since only the trailing suffix is read.
 
 ### Codes and the Base Builder Code
 
-The `codes` field is a list, so a transaction can carry more than one code. For direct integrators the default is **your trading name alone**, on every EVM network including Base.
+The `codes` field is a list, so a transaction can carry more than one code, comma-joined. For direct integrators the default is **your own code alone**, on every EVM network including Base.
 
 <Callout type="warning">
-  `bc_julg9gbq` is **Paycrest/noblocks' own registered Base Builder Code**, used for base.dev analytics and rewards on Base mainnet. It identifies Paycrest as the originating app. Do not include it in your own transactions unless you have an explicit co-branding arrangement with Paycrest; it is not a code for arbitrary senders to claim.
+  `bc_julg9gbq` is **Paycrest/Noblocks' own registered Base Builder Code**, appended by the Noblocks app on Base mainnet for base.dev analytics and rewards. It identifies Noblocks as the originating app. Do not include it in your own transactions unless you have an explicit co-branding arrangement with Paycrest: it is not a code for arbitrary senders to claim.
 </Callout>
 
-The on-chain suffix is for public attribution only. Sender identification for order processing uses `metadata.apiKey` inside the encrypted `messageHash`.
+### Relationship to `metadata.apiKey`
 
-### Precedence and backward compatibility
-
-`metadata.apiKey` continues to work unchanged and is **not deprecated**. It is the **primary mechanism** for sender identification. The onchain suffix is a **public attribution tag** only.
+`metadata.apiKey` is unchanged, **not deprecated**, and remains the single mechanism by which the aggregator identifies the sender behind an order. Keep sending it exactly as before.
 
 | Present | Sender resolution |
 |---------|-------------------|
-| `metadata.apiKey` only | `metadata.apiKey` — this is the standard path |
-| Onchain suffix only | `metadata.apiKey` fallback (suffix is not used for sender resolution) |
-| Both | `metadata.apiKey` is authoritative |
-| Suffix malformed | No impact — sender resolution uses `metadata.apiKey` |
+| `metadata.apiKey` only | `metadata.apiKey` |
+| Onchain suffix only | **Order is not attributed to a sender.** The suffix is not read for identification |
+| Both | `metadata.apiKey` |
+| Suffix malformed or absent | No effect: resolution uses `metadata.apiKey` |
 
 <Callout type="warning">
-  The on-chain suffix is a **public, human-readable attribution tag** (e.g., your trading name). It is not used for sender identification or order processing. Sender resolution always uses `metadata.apiKey` inside the encrypted `messageHash`.
+  Appending a suffix does **not** replace `metadata.apiKey`. An order created with a suffix but without `metadata.apiKey` will not be linked to your sender profile, and you will not receive webhooks for it.
 </Callout>
 
-Onchain attribution never breaks order indexing: any parse failure or RPC error has no impact on sender resolution, which continues to use `metadata.apiKey`.
+The suffix is unauthenticated calldata that anyone can write, which is exactly why it stays a display tag and never feeds sender resolution. Adding one can never break order indexing: a malformed suffix, an unknown code, or no suffix at all leaves processing untouched.
 
 ### Network support
 
-Onchain attribution applies to **EVM networks only**. On **Starknet** and **Tron**, the suffix is not read and attribution continues to use `metadata.apiKey` exclusively.
-
-<Note>
-  Embed host attribution — the `e_`-prefixed codes emitted by the Noblocks widget to identify an embedding partner site — is a separate concern handled by the widget itself. Direct smart contract integrators do not need it.
-</Note>
+Onchain attribution applies to **EVM networks only**. On **Starknet** and **Tron** no suffix is appended or read, and attribution works from `metadata.apiKey` exclusively.
 
 **References:** [ERC-8021 specification](https://eip.tools/eip/8021)
+
 
 ## Token Approval
 

--- a/implementation-guides/smart-contract-interaction.mdx
+++ b/implementation-guides/smart-contract-interaction.mdx
@@ -607,7 +607,7 @@ The suffix is execution-inert: the Gateway contract ignores trailing bytes beyon
 | **Direct Gateway integration** (this guide) | You, on your own `createOrder` calldata | Whatever you choose to publish |
 | **Noblocks** on Base mainnet | The Noblocks app | Its registered Base Builder Code |
 
-On the Sender API path the aggregator appends the suffix to the keeper transactions it submits on its native EIP-7702 relayer, covering create, settle, and refund. Senders with no trading name on their KYB profile get no suffix. There is nothing to configure.
+On the Sender API path the aggregator appends the suffix to the transactions it submits for an order: creation, settlement, and refunds. Senders with no trading name on their KYB profile get no suffix. There is nothing to configure.
 
 If you call the Gateway contract directly, nothing is appended for you. The rest of this section covers appending your own.
 
@@ -655,6 +655,11 @@ import { concatHex, stringToHex, toHex } from "viem";
 const ERC8021_MARKER = `0x${"8021".repeat(8)}`;
 
 function encodeAttributionSuffix(codes) {
+  for (const code of codes) {
+    if (!code || code.includes(",")) {
+      throw new Error("ERC-8021 codes must be non-empty and comma-free");
+    }
+  }
   const joined = codes.join(",");
   if (!joined || joined.length > 255) {
     throw new Error("ERC-8021 codes must be 1-255 bytes once joined");
@@ -679,6 +684,9 @@ function encodeAttributionSuffix(codes) {
 ERC8021_MARKER = bytes.fromhex("8021" * 8)
 
 def encode_attribution_suffix(codes):
+    for code in codes:
+        if not code or "," in code:
+            raise ValueError("ERC-8021 codes must be non-empty and comma-free")
     joined = ",".join(codes)
     if not joined or len(joined) > 255:
         raise ValueError("ERC-8021 codes must be 1-255 bytes once joined")
@@ -700,6 +708,11 @@ import (
 var erc8021Marker = common.Hex2Bytes("80218021802180218021802180218021")
 
 func encodeAttributionSuffix(codes []string) ([]byte, error) {
+    for _, code := range codes {
+        if code == "" || strings.Contains(code, ",") {
+            return nil, fmt.Errorf("ERC-8021 codes must be non-empty and comma-free")
+        }
+    }
     joined := strings.Join(codes, ",")
     if joined == "" || len(joined) > 255 {
         return nil, fmt.Errorf("ERC-8021 codes must be 1-255 bytes once joined")
@@ -867,7 +880,7 @@ The `codes` field is a list, so a transaction can carry more than one code, comm
   Appending a suffix does **not** replace `metadata.apiKey`. An order created with a suffix but without `metadata.apiKey` will not be linked to your sender profile, and you will not receive webhooks for it.
 </Callout>
 
-The suffix is unauthenticated calldata that anyone can write, which is exactly why it stays a display tag and never feeds sender resolution. Adding one can never break order indexing: a malformed suffix, an unknown code, or no suffix at all leaves processing untouched.
+Adding a suffix can never break order indexing. A malformed suffix, an unrecognized code, or no suffix at all leaves order processing untouched.
 
 ### Network support
 

--- a/implementation-guides/smart-contract-interaction.mdx
+++ b/implementation-guides/smart-contract-interaction.mdx
@@ -472,6 +472,10 @@ The recipient object is encrypted with the aggregator's public key to produce th
   Your API Key is available in the dashboard at [app.paycrest.io](https://app.paycrest.io).
 </Note>
 
+<Note>
+  On EVM networks you can additionally (or instead) attribute orders with an onchain ERC-8021 data suffix. See [Onchain Attribution (ERC-8021)](#onchain-attribution-erc-8021).
+</Note>
+
 <Tabs>
   <Tab title="JavaScript">
 ```javascript
@@ -580,6 +584,288 @@ curl -X GET "https://api.paycrest.io/v2/pubkey"
 ```
   </Tab>
 </Tabs>
+
+## Onchain Attribution (ERC-8021)
+
+On EVM networks you can attribute your `createOrder` transactions onchain by appending an [ERC-8021](https://eip.tools/eip/8021) data suffix to the transaction calldata. The aggregator's indexer reads the suffix from the transaction and links the resulting order to your sender profile, enabling webhooks and order attribution without depending solely on `metadata.apiKey` inside the encrypted `messageHash`.
+
+The suffix is execution-inert: the Gateway contract ignores trailing bytes beyond its expected ABI arguments, so the suffix passes through without affecting execution. Cost is roughly 16 gas per non-zero byte.
+
+<Note>
+  One suffix covers **every order in the transaction**, whereas `metadata.apiKey` is carried per order inside that order's encrypted `messageHash`. This matters for the precedence rules below.
+</Note>
+
+### Your sender code
+
+Your sender code is your **API Key ID** with dashes stripped — a 32-character hex string. Find it in the dashboard at [app.paycrest.io](https://app.paycrest.io).
+
+```javascript
+// 7f3a9c21-4b6e-4d18-9a52-c0e8d1f24b7a
+const senderCode = process.env.PAYCREST_API_KEY_ID.replaceAll("-", "");
+// "7f3a9c214b6e4d189a52c0e8d1f24b7a"
+```
+
+<Callout type="warning">
+  The API Key ID is **public attribution material** and is permanently visible onchain once used. Your API **secret** is never placed onchain and remains for webhooks and REST authentication only.
+</Callout>
+
+### Suffix layout
+
+Schema 0, parsed **backwards from the end** of the calldata:
+
+| Field | Size | Value |
+|-------|------|-------|
+| `codes` | variable | Comma-joined ASCII codes |
+| `length` | 1 byte | Byte length of `codes` |
+| `schemaId` | 1 byte | `0x00` |
+| `marker` | 16 bytes | `0x8021` repeated 8 times |
+
+Constraints: `codes` must be printable ASCII (`0x20`–`0x7e`) and at most **255 bytes** once joined. Violating either makes the suffix unparseable, and the order silently falls back to `metadata.apiKey` attribution.
+
+**Worked example** for API Key ID `7f3a9c21-4b6e-4d18-9a52-c0e8d1f24b7a` on a non-Base EVM chain:
+
+```text
+3766336139633231346236653464313839613532633065386431663234623761 20 00 80218021802180218021802180218021
+└──────── "7f3a9c214b6e4d189a52c0e8d1f24b7a" (32 bytes) ────────┘ len schema        marker
+                                                                 0x20  0x00
+```
+
+### Encoding the suffix
+
+<Tabs>
+  <Tab title="JavaScript">
+```javascript
+import { concatHex, stringToHex, toHex } from "viem";
+
+const ERC8021_MARKER = `0x${"8021".repeat(8)}`;
+
+function encodeAttributionSuffix(codes) {
+  const joined = codes.join(",");
+  if (!joined || joined.length > 255) {
+    throw new Error("ERC-8021 codes must be 1-255 bytes once joined");
+  }
+  for (let i = 0; i < joined.length; i++) {
+    const c = joined.charCodeAt(i);
+    if (c < 0x20 || c > 0x7e) {
+      throw new Error("ERC-8021 codes must be printable ASCII");
+    }
+  }
+  return concatHex([
+    stringToHex(joined),
+    toHex(joined.length, { size: 1 }),
+    "0x00",
+    ERC8021_MARKER,
+  ]);
+}
+```
+  </Tab>
+  <Tab title="Python">
+```python
+ERC8021_MARKER = bytes.fromhex("8021" * 8)
+
+def encode_attribution_suffix(codes):
+    joined = ",".join(codes)
+    if not joined or len(joined) > 255:
+        raise ValueError("ERC-8021 codes must be 1-255 bytes once joined")
+    encoded = joined.encode("ascii")
+    if any(b < 0x20 or b > 0x7e for b in encoded):
+        raise ValueError("ERC-8021 codes must be printable ASCII")
+    return encoded + bytes([len(encoded), 0x00]) + ERC8021_MARKER
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "fmt"
+    "strings"
+
+    "github.com/ethereum/go-ethereum/common"
+)
+
+var erc8021Marker = common.Hex2Bytes("80218021802180218021802180218021")
+
+func encodeAttributionSuffix(codes []string) ([]byte, error) {
+    joined := strings.Join(codes, ",")
+    if joined == "" || len(joined) > 255 {
+        return nil, fmt.Errorf("ERC-8021 codes must be 1-255 bytes once joined")
+    }
+    for i := 0; i < len(joined); i++ {
+        if joined[i] < 0x20 || joined[i] > 0x7e {
+            return nil, fmt.Errorf("ERC-8021 codes must be printable ASCII")
+        }
+    }
+    out := make([]byte, 0, len(joined)+2+len(erc8021Marker))
+    out = append(out, joined...)
+    out = append(out, byte(len(joined)), 0x00)
+    out = append(out, erc8021Marker...)
+    return out, nil
+}
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+# Suffix encoding is a calldata construction step and has no cURL equivalent.
+# Use one of the programming language examples above.
+```
+  </Tab>
+</Tabs>
+
+### Appending to createOrder
+
+The suffix must be appended to the calldata **before signing and gas estimation** so it is covered by the signature and paid for in the gas limit.
+
+<Callout type="warning">
+  Viem's `writeContract` and `simulate` helpers build calldata internally and give you no place to append raw bytes. To attach a suffix, encode the call yourself with `encodeFunctionData` and send it with `sendTransaction`.
+</Callout>
+
+<Tabs>
+  <Tab title="JavaScript">
+```javascript
+import { concatHex, encodeFunctionData, parseUnits, zeroAddress } from "viem";
+
+async function createOffRampOrderAttributed(amount, recipient, refundAddress) {
+  const rate = await getExchangeRate();
+  const accountName = await verifyAccount(recipient);
+  const messageHash = await encryptRecipientData({
+    ...recipient,
+    accountName,
+    // Optional once the onchain suffix is in place; see Precedence below.
+    metadata: { apiKey: process.env.PAYCREST_API_KEY },
+  });
+  await approveUSDT(amount);
+
+  const callData = encodeFunctionData({
+    abi: GATEWAY_ABI,
+    functionName: "createOrder",
+    args: [
+      USDT_ADDRESS,
+      parseUnits(amount, 6),
+      rate,
+      zeroAddress,
+      0n,
+      refundAddress,
+      messageHash,
+    ],
+  });
+
+  const senderCode = process.env.PAYCREST_API_KEY_ID.replaceAll("-", "");
+  const data = concatHex([callData, encodeAttributionSuffix([senderCode])]);
+
+  const hash = await walletClient.sendTransaction({
+    to: GATEWAY_ADDRESS,
+    data,
+  });
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  return { orderId: extractOrderId(receipt), transactionHash: receipt.transactionHash };
+}
+```
+  </Tab>
+  <Tab title="Python">
+```python
+tx = gateway.functions.createOrder(
+    USDT_ADDRESS,
+    w3.to_wei(amount, 'ether'),
+    rate,
+    '0x0000000000000000000000000000000000000000',
+    0,
+    refund_address,
+    message_hash
+).build_transaction({
+    'from': user_address,
+    'nonce': w3.eth.get_transaction_count(user_address),
+})
+
+sender_code = os.environ['PAYCREST_API_KEY_ID'].replace('-', '')
+tx['data'] = tx['data'] + encode_attribution_suffix([sender_code]).hex()
+
+# Estimate gas AFTER appending so the suffix is covered.
+tx['gas'] = w3.eth.estimate_gas(tx)
+tx['gasPrice'] = w3.eth.gas_price
+
+signed_tx = w3.eth.account.sign_transaction(tx, private_key)
+tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+```
+  </Tab>
+  <Tab title="Go">
+```go
+callData, err := gatewayABI.Pack(
+    "createOrder",
+    tokenAddress, amount, rate, senderFeeRecipient, senderFee, refundAddress, messageHash,
+)
+if err != nil {
+    return err
+}
+
+senderCode := strings.ReplaceAll(os.Getenv("PAYCREST_API_KEY_ID"), "-", "")
+suffix, err := encodeAttributionSuffix([]string{senderCode})
+if err != nil {
+    return err
+}
+data := append(callData, suffix...)
+
+// Estimate gas against the suffixed calldata.
+gasLimit, err := client.EstimateGas(ctx, ethereum.CallMsg{
+    From: fromAddress,
+    To:   &gatewayAddress,
+    Data: data,
+})
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+# Smart contract interactions are typically done in your application code
+# rather than with cURL. Use one of the programming language examples above.
+```
+  </Tab>
+</Tabs>
+
+### Where the suffix must live
+
+The indexer reads the **outer transaction calldata** for the transaction that emitted the `OrderCreated` event, then parses backwards from its final byte.
+
+- **EOA senders**: append to `tx.data`.
+- **Account abstraction / smart accounts**: append to the **outer** `userOp.callData` — the top-level input that lands onchain.
+- **Do not** bury the suffix inside a nested or inner call. A suffix on an inner call is not visible to the parser, because ABI encoding pads inner `bytes` fields and the outer calldata will not end with the marker.
+
+Anything that appends bytes after your suffix will also break parsing, since only the trailing suffix is read.
+
+### Codes and the Base Builder Code
+
+The `codes` field is a list, so a transaction can carry more than one code. For direct integrators the default is **your sender code alone**, on every EVM network including Base.
+
+<Callout type="warning">
+  `bc_julg9gbq` is **Paycrest/noblocks' own registered Base Builder Code**, used for base.dev analytics and rewards on Base mainnet. It identifies Paycrest as the originating app. Do not include it in your own transactions unless you have an explicit co-branding arrangement with Paycrest; it is not a code for arbitrary senders to claim.
+</Callout>
+
+Sender resolution scans the code list for the first entry that is exactly 32 characters and parses as a UUID, so non-UUID codes such as `bc_julg9gbq` are skipped and code ordering does not matter.
+
+### Precedence and backward compatibility
+
+`metadata.apiKey` continues to work unchanged and is **not deprecated**. The onchain suffix is the preferred mechanism for new EVM integrations, and the two can be used together.
+
+| Present | Resolved sender |
+|---------|-----------------|
+| Onchain suffix only | Onchain suffix — this is the direct-integrator path |
+| `metadata.apiKey` only | `metadata.apiKey` |
+| Both, naming the same key | Onchain suffix |
+| **Both, naming different keys** | **`metadata.apiKey` wins**, and the divergence is logged as a possible spoofing attempt |
+| Suffix malformed, or key not found | Falls back to `metadata.apiKey` |
+
+<Callout type="warning">
+  The suffix is **unauthenticated**. It rides on attacker-controllable calldata and can name any active API Key ID, with no signature binding it to the transaction sender. `metadata.apiKey` is forgeable in the same way on its own, but it is scoped to a single order inside that order's encrypted `messageHash`, whereas one suffix covers every order in the transaction. That is why metadata is authoritative when the two disagree.
+</Callout>
+
+Onchain attribution never breaks order indexing: any parse failure, RPC error, or unresolvable key falls back to metadata rather than rejecting the order.
+
+### Network support
+
+Onchain attribution applies to **EVM networks only**. On **Starknet** and **Tron**, the suffix is not read and attribution continues to use `metadata.apiKey` exclusively.
+
+<Note>
+  Embed host attribution — the `e_`-prefixed codes emitted by the Noblocks widget to identify an embedding partner site — is a separate concern handled by the widget itself. Direct smart contract integrators do not need it.
+</Note>
+
+**References:** [ERC-8021 specification](https://eip.tools/eip/8021)
 
 ## Token Approval
 

--- a/implementation-guides/smart-contract-interaction.mdx
+++ b/implementation-guides/smart-contract-interaction.mdx
@@ -587,26 +587,25 @@ curl -X GET "https://api.paycrest.io/v2/pubkey"
 
 ## Onchain Attribution (ERC-8021)
 
-On EVM networks you can attribute your `createOrder` transactions onchain by appending an [ERC-8021](https://eip.tools/eip/8021) data suffix to the transaction calldata. The aggregator's indexer reads the suffix from the transaction and links the resulting order to your sender profile, enabling webhooks and order attribution without depending solely on `metadata.apiKey` inside the encrypted `messageHash`.
+On EVM networks you can attribute your `createOrder` transactions onchain by appending an [ERC-8021](https://eip.tools/eip/8021) data suffix to the transaction calldata. The suffix carries your **trading name** as a public, human-readable attribution tag.
 
 The suffix is execution-inert: the Gateway contract ignores trailing bytes beyond its expected ABI arguments, so the suffix passes through without affecting execution. Cost is roughly 16 gas per non-zero byte.
 
 <Note>
-  One suffix covers **every order in the transaction**, whereas `metadata.apiKey` is carried per order inside that order's encrypted `messageHash`. This matters for the precedence rules below.
+  The on-chain suffix is for **public attribution only**. Sender identification for order processing (webhooks, order lookup) continues to use `metadata.apiKey` inside the encrypted `messageHash`. The suffix is a human-readable tag; the encrypted metadata is the authoritative source for sender resolution.
 </Note>
 
 ### Your sender code
 
-Your sender code is your **API Key ID** with dashes stripped — a 32-character hex string. Find it in the dashboard at [app.paycrest.io](https://app.paycrest.io).
+Your sender code is your **trading name** from your KYB profile — a human-readable business identifier. Find it in the dashboard at [app.paycrest.io](https://app.paycrest.io).
 
 ```javascript
-// 7f3a9c21-4b6e-4d18-9a52-c0e8d1f24b7a
-const senderCode = process.env.PAYCREST_API_KEY_ID.replaceAll("-", "");
-// "7f3a9c214b6e4d189a52c0e8d1f24b7a"
+// Your trading name from KYB profile
+const senderCode = "AcmeCorp";
 ```
 
 <Callout type="warning">
-  The API Key ID is **public attribution material** and is permanently visible onchain once used. Your API **secret** is never placed onchain and remains for webhooks and REST authentication only.
+  The trading name is **public attribution material** and is permanently visible onchain once used. It's a human-readable tag for attribution purposes. Your API **secret** is never placed onchain and remains for webhooks and REST authentication only.
 </Callout>
 
 ### Suffix layout
@@ -622,12 +621,12 @@ Schema 0, parsed **backwards from the end** of the calldata:
 
 Constraints: `codes` must be printable ASCII (`0x20`–`0x7e`) and at most **255 bytes** once joined. Violating either makes the suffix unparseable, and the order silently falls back to `metadata.apiKey` attribution.
 
-**Worked example** for API Key ID `7f3a9c21-4b6e-4d18-9a52-c0e8d1f24b7a` on a non-Base EVM chain:
+**Worked example** for trading name `AcmeCorp` on a non-Base EVM chain:
 
 ```text
-3766336139633231346236653464313839613532633065386431663234623761 20 00 80218021802180218021802180218021
-└──────── "7f3a9c214b6e4d189a52c0e8d1f24b7a" (32 bytes) ────────┘ len schema        marker
-                                                                 0x20  0x00
+41636d65436f7270 08 00 80218021802180218021802180218021
+└── "AcmeCorp" ──┘ len schema        marker
+                  0x08  0x00
 ```
 
 ### Encoding the suffix
@@ -748,7 +747,7 @@ async function createOffRampOrderAttributed(amount, recipient, refundAddress) {
     ],
   });
 
-  const senderCode = process.env.PAYCREST_API_KEY_ID.replaceAll("-", "");
+  const senderCode = "AcmeCorp"; // Your trading name from KYB profile
   const data = concatHex([callData, encodeAttributionSuffix([senderCode])]);
 
   const hash = await walletClient.sendTransaction({
@@ -775,7 +774,7 @@ tx = gateway.functions.createOrder(
     'nonce': w3.eth.get_transaction_count(user_address),
 })
 
-sender_code = os.environ['PAYCREST_API_KEY_ID'].replace('-', '')
+sender_code = "AcmeCorp"  # Your trading name from KYB profile
 tx['data'] = tx['data'] + encode_attribution_suffix([sender_code]).hex()
 
 # Estimate gas AFTER appending so the suffix is covered.
@@ -796,7 +795,7 @@ if err != nil {
     return err
 }
 
-senderCode := strings.ReplaceAll(os.Getenv("PAYCREST_API_KEY_ID"), "-", "")
+senderCode := "AcmeCorp" // Your trading name from KYB profile
 suffix, err := encodeAttributionSuffix([]string{senderCode})
 if err != nil {
     return err
@@ -831,31 +830,30 @@ Anything that appends bytes after your suffix will also break parsing, since onl
 
 ### Codes and the Base Builder Code
 
-The `codes` field is a list, so a transaction can carry more than one code. For direct integrators the default is **your sender code alone**, on every EVM network including Base.
+The `codes` field is a list, so a transaction can carry more than one code. For direct integrators the default is **your trading name alone**, on every EVM network including Base.
 
 <Callout type="warning">
   `bc_julg9gbq` is **Paycrest/noblocks' own registered Base Builder Code**, used for base.dev analytics and rewards on Base mainnet. It identifies Paycrest as the originating app. Do not include it in your own transactions unless you have an explicit co-branding arrangement with Paycrest; it is not a code for arbitrary senders to claim.
 </Callout>
 
-Sender resolution scans the code list for the first entry that is exactly 32 characters and parses as a UUID, so non-UUID codes such as `bc_julg9gbq` are skipped and code ordering does not matter.
+The on-chain suffix is for public attribution only. Sender identification for order processing uses `metadata.apiKey` inside the encrypted `messageHash`.
 
 ### Precedence and backward compatibility
 
-`metadata.apiKey` continues to work unchanged and is **not deprecated**. The onchain suffix is the preferred mechanism for new EVM integrations, and the two can be used together.
+`metadata.apiKey` continues to work unchanged and is **not deprecated**. It is the **primary mechanism** for sender identification. The onchain suffix is a **public attribution tag** only.
 
-| Present | Resolved sender |
-|---------|-----------------|
-| Onchain suffix only | Onchain suffix — this is the direct-integrator path |
-| `metadata.apiKey` only | `metadata.apiKey` |
-| Both, naming the same key | Onchain suffix |
-| **Both, naming different keys** | **`metadata.apiKey` wins**, and the divergence is logged as a possible spoofing attempt |
-| Suffix malformed, or key not found | Falls back to `metadata.apiKey` |
+| Present | Sender resolution |
+|---------|-------------------|
+| `metadata.apiKey` only | `metadata.apiKey` — this is the standard path |
+| Onchain suffix only | `metadata.apiKey` fallback (suffix is not used for sender resolution) |
+| Both | `metadata.apiKey` is authoritative |
+| Suffix malformed | No impact — sender resolution uses `metadata.apiKey` |
 
 <Callout type="warning">
-  The suffix is **unauthenticated**. It rides on attacker-controllable calldata and can name any active API Key ID, with no signature binding it to the transaction sender. `metadata.apiKey` is forgeable in the same way on its own, but it is scoped to a single order inside that order's encrypted `messageHash`, whereas one suffix covers every order in the transaction. That is why metadata is authoritative when the two disagree.
+  The on-chain suffix is a **public, human-readable attribution tag** (e.g., your trading name). It is not used for sender identification or order processing. Sender resolution always uses `metadata.apiKey` inside the encrypted `messageHash`.
 </Callout>
 
-Onchain attribution never breaks order indexing: any parse failure, RPC error, or unresolvable key falls back to metadata rather than rejecting the order.
+Onchain attribution never breaks order indexing: any parse failure or RPC error has no impact on sender resolution, which continues to use `metadata.apiKey`.
 
 ### Network support
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -11,14 +11,16 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ### Onchain sender attribution via ERC-8021 (August 2026)
 
-**New:** Direct Gateway integrators can attribute `createOrder` transactions onchain by appending an [ERC-8021](https://eip.tools/eip/8021) schema-0 data suffix to the outer transaction calldata. The indexer parses the suffix and links the order to the sender profile, so webhooks and attribution no longer depend solely on `metadata.apiKey`.
+**New:** Direct Gateway integrators can attribute `createOrder` transactions onchain by appending an [ERC-8021](https://eip.tools/eip/8021) schema-0 data suffix to the outer transaction calldata. The suffix carries the sender's **trading name** (from their KYB profile) as a public, human-readable attribution tag.
 
-- **Sender code** — your API Key ID with dashes stripped (32 hex chars).
+- **Sender code** — your trading name from your KYB profile (e.g., "AcmeCorp").
 - **Suffix layout** (parsed backwards from the end of calldata): comma-joined ASCII `codes` · 1-byte length · 1-byte schema `0x00` · 16-byte marker `0x8021…8021`.
 - **Placement** — the suffix must sit on the outer `tx.data` / `userOp.callData`, not on a nested inner call.
 - **EVM only** — Starknet and Tron continue to use `metadata.apiKey` exclusively.
 
-**Unchanged:** `metadata.apiKey` still works and is not deprecated. Where both are present and name **different** keys, `metadata.apiKey` wins and the divergence is logged, because the suffix is unauthenticated and covers every order in the transaction while metadata is scoped to a single order inside its encrypted `messageHash`.
+**Important:** The on-chain suffix is for **public attribution only**. Sender identification for order processing (webhooks, order lookup) continues to use `metadata.apiKey` inside the encrypted `messageHash`. The suffix is a human-readable tag; the encrypted metadata is the authoritative source for sender resolution.
+
+**Unchanged:** `metadata.apiKey` still works and is not deprecated. It remains the primary mechanism for sender identification.
 
 See [Onchain Attribution (ERC-8021)](/implementation-guides/smart-contract-interaction#onchain-attribution-erc-8021).
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -9,6 +9,21 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ## Q3 2026
 
+### Onchain sender attribution via ERC-8021 (August 2026)
+
+**New:** Direct Gateway integrators can attribute `createOrder` transactions onchain by appending an [ERC-8021](https://eip.tools/eip/8021) schema-0 data suffix to the outer transaction calldata. The indexer parses the suffix and links the order to the sender profile, so webhooks and attribution no longer depend solely on `metadata.apiKey`.
+
+- **Sender code** — your API Key ID with dashes stripped (32 hex chars).
+- **Suffix layout** (parsed backwards from the end of calldata): comma-joined ASCII `codes` · 1-byte length · 1-byte schema `0x00` · 16-byte marker `0x8021…8021`.
+- **Placement** — the suffix must sit on the outer `tx.data` / `userOp.callData`, not on a nested inner call.
+- **EVM only** — Starknet and Tron continue to use `metadata.apiKey` exclusively.
+
+**Unchanged:** `metadata.apiKey` still works and is not deprecated. Where both are present and name **different** keys, `metadata.apiKey` wins and the divergence is logged, because the suffix is unauthenticated and covers every order in the transaction while metadata is scoped to a single order inside its encrypted `messageHash`.
+
+See [Onchain Attribution (ERC-8021)](/implementation-guides/smart-contract-interaction#onchain-attribution-erc-8021).
+
+---
+
 ### Markets orderbook query filters (July 2026)
 
 **Updated:** `GET /v2/markets` accepts optional query filters to narrow the returned orderbook:

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -11,7 +11,7 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ### Onchain sender attribution via ERC-8021 (August 2026)
 
-**New:** The aggregator now stamps the EVM transactions it submits with an [ERC-8021](https://eip.tools/eip/8021) schema-0 data suffix carrying the sender's **trading name** from their KYB profile. It is applied on the native EIP-7702 relayer path for create, settle, and refund transactions, so orders placed through the Sender API carry public onchain attribution with no integration work.
+**New:** The aggregator now stamps the EVM transactions it submits with an [ERC-8021](https://eip.tools/eip/8021) schema-0 data suffix carrying the sender's **trading name** from their KYB profile. It is applied to the transactions the aggregator submits for an order: creation, settlement, and refunds. Orders placed through the Sender API carry public onchain attribution with no integration work.
 
 - **Sender code**: the sender's KYB trading name (for example, `AcmeCorp`). Senders with no trading name on file get no suffix.
 - **Suffix layout** (parsed backwards from the end of calldata): comma-joined ASCII `codes` · 1-byte length · 1-byte schema `0x00` · 16-byte marker `0x8021...8021`.


### PR DESCRIPTION
Introduce onchain sender attribution for `createOrder` transactions on EVM networks by appending an ERC-8021 data suffix to the transaction calldata. This allows for improved order attribution without relying solely on `metadata.apiKey`. Update documentation to include sender code details, suffix layout, encoding examples in multiple programming languages, and guidelines for appending the suffix to transactions. Update changelog to reflect this new feature.