### PR TITLE
docs(webhooks): document payment_order.compliance_hold

### DIFF
--- a/api-reference/general/get-markets.mdx
+++ b/api-reference/general/get-markets.mdx
@@ -37,7 +37,7 @@ Each element of `book` is a single provider quote for one `side` on one `network
 | Field | Type | Description |
 |-------|------|-------------|
 | `providerId` | string | Provider identifier |
-| `side` | string | `sell` = offramp (crypto → fiat); `buy` = onramp (fiat → crypto) |
+| `side` | string | `sell` = off-ramp (crypto → fiat); `buy` = on-ramp (fiat → crypto) |
 | `token` | string | Token symbol, e.g. `USDT`, `USDC` |
 | `fiat` | string | Fiat currency code, e.g. `NGN`, `KES` |
 | `network` | string | Network identifier, e.g. `base`, `ethereum` |

--- a/api-reference/general/get-token-rate.mdx
+++ b/api-reference/general/get-token-rate.mdx
@@ -18,7 +18,7 @@ Get buy and/or sell quotes on a **specific network**—either a **token + fiat**
 | `amount` | For **token + fiat**: crypto (token) notional. For **fiat + fiat**: amount in **`from`** fiat. |
 | `to` | Fiat currency code **or** token symbol on `network` (paired with `from`) |
 
-**Token + fiat:** exactly **one** fiat and **one** token (`.../USDT/100/NGN` ≡ `.../NGN/100/USDT`). **`from`/`to` cannot both be tokens.** **Path order does not imply trade direction**—use `side` or read **`data.buy`** / **`data.sell`** for onramp vs offramp display.
+**Token + fiat:** exactly **one** fiat and **one** token (`.../USDT/100/NGN` ≡ `.../NGN/100/USDT`). **`from`/`to` cannot both be tokens.** **Path order does not imply trade direction**—use `side` or read **`data.buy`** / **`data.sell`** for on-ramp vs off-ramp display.
 
 **Fiat + fiat:** both are fiat codes; the server quotes through **USDC** on the same network. **`sell.rate`** = **`to` per 1 `from`**. **`buy.rate`** = **`from` per 1 `to`** (inverse corridor, **not** the reciprocal of `sell`—each side uses the appropriate leg bid/ask).
 
@@ -92,6 +92,6 @@ When `side=buy` or `side=sell`, only that key is present under `data`.
 
 ## Rate resolution
 
-Behavior matches the priority-queue–based resolution used when creating orders: the quote reflects provider selection and validation for the requested **side** (`buy` vs `sell`). **Path segment order (`from` / `to`) does not select direction**—use `?side=`, or read **`data.sell`** for **offramp** (crypto → fiat) display and **`data.buy`** for **onramp** (fiat → crypto) before `POST /v2/sender/orders`.
+Behavior matches the priority-queue–based resolution used when creating orders: the quote reflects provider selection and validation for the requested **side** (`buy` vs `sell`). **Path segment order (`from` / `to`) does not select direction**—use `?side=`, or read **`data.sell`** for **off-ramp** (crypto → fiat) display and **`data.buy`** for **on-ramp** (fiat → crypto) before `POST /v2/sender/orders`.
 
 See also [Get Token Rate (v1)](/api-reference/general/get-token-rate-v1) for the legacy scalar response.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -401,6 +401,7 @@ Set up webhooks to receive real-time updates:
 - **`payment_order.refunding`** - Refund transaction initiated
 - **`payment_order.refunded`** - Deposit refunded to sender (fulfillment failed)
 - **`payment_order.expired`** - Order expired with no deposit received
+- **`payment_order.compliance_hold`** - Onramp fiat received, but settlement is held pending compliance review. Unlike the events above, this one is not named after a status: the order stays `pending`, so `data.status` reports `pending`
 
 ### Webhook Payload
 

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -47,7 +47,7 @@ The Paycrest API is organized into three main categories:
 
 For entities that create payment orders:
 
-- **`POST /sender/orders`** - Create a new payment order (offramp or onramp)
+- **`POST /sender/orders`** - Create a new payment order (off-ramp or on-ramp)
 - **`GET /sender/orders`** - List payment orders with filtering
 - **`GET /sender/orders/{id}`** - Get a specific payment order
 - **`GET /sender/stats`** - Get sender statistics
@@ -401,7 +401,7 @@ Set up webhooks to receive real-time updates:
 - **`payment_order.refunding`** - Refund transaction initiated
 - **`payment_order.refunded`** - Deposit refunded to sender (fulfillment failed)
 - **`payment_order.expired`** - Order expired with no deposit received
-- **`payment_order.compliance_hold`** - Onramp fiat received, but settlement is held pending compliance review. Unlike the events above, this one is not named after a status: the order stays `pending`, so `data.status` reports `pending`
+- **`payment_order.compliance_hold`** - On-ramp fiat received, but settlement is held pending compliance review. Unlike the events above, this one is not named after a status: the order stays `pending`, so `data.status` reports `pending`
 
 ### Webhook Payload
 

--- a/api-reference/provider/get-market-rate.mdx
+++ b/api-reference/provider/get-market-rate.mdx
@@ -34,8 +34,8 @@ When qualifying public offers exist for this corridor, each side includes a `pos
 | `deltaVsBest` | string | `yourEffectiveRate − bestPublicRate` |
 
 **Interpreting `deltaVsBest`:**
-- **Sell** (offramp): a **positive** delta means your rate is higher than the best peer — you are more competitive.
-- **Buy** (onramp): a **negative** delta means your rate is lower than the best peer — you are more competitive.
+- **Sell** (off-ramp): a **positive** delta means your rate is higher than the best peer — you are more competitive.
+- **Buy** (on-ramp): a **negative** delta means your rate is lower than the best peer — you are more competitive.
 
 `position` is **omitted** when:
 - No qualifying public offers exist for the corridor, or

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -39,7 +39,7 @@ The **Gateway contract** is the onchain entry point for all payment orders. It h
 
 #### Key Functions
 
-- **Order Creation**: Accepts payment orders from senders; locks stablecoins in escrow (offramp) or coordinates stablecoin release to recipients (onramp)
+- **Order Creation**: Accepts payment orders from senders; locks stablecoins in escrow (off-ramp) or coordinates stablecoin release to recipients (on-ramp)
 - **Event Emission**: Emits events that the aggregator monitors to begin routing
 - **Escrow Settlement**: Releases escrowed funds to providers after fulfillment is verified, or returns them to senders if the order can't be completed
 
@@ -47,16 +47,16 @@ The **Gateway contract** is the onchain entry point for all payment orders. It h
 
 <Steps>
   <Step title="Order Creation">
-    Sender creates an order via the Sender API or direct contract interaction. For offramp, stablecoins are locked in escrow. For onramp, the contract coordinates stablecoin release once fiat receipt is confirmed.
+    Sender creates an order via the Sender API or direct contract interaction. For off-ramp, stablecoins are locked in escrow. For on-ramp, the contract coordinates stablecoin release once fiat receipt is confirmed.
   </Step>
   <Step title="Routing">
     Aggregator picks up the onchain event and routes the order to the most suitable liquidity provider based on rate, availability, and corridor.
   </Step>
   <Step title="Fulfillment">
-    For offramp, the provider disburses fiat to the recipient via a local PSP. For onramp, the provider receives the user's fiat deposit and reports confirmation.
+    For off-ramp, the provider disburses fiat to the recipient via a local PSP. For on-ramp, the provider receives the user's fiat deposit and reports confirmation.
   </Step>
   <Step title="Completion">
-    After fulfillment is verified, the contract settles atomically: escrowed stablecoins are released to the provider (offramp), or stablecoins are transferred to the recipient's wallet (onramp). If fulfillment fails, funds are automatically returned.
+    After fulfillment is verified, the contract settles atomically: escrowed stablecoins are released to the provider (off-ramp), or stablecoins are transferred to the recipient's wallet (on-ramp). If fulfillment fails, funds are automatically returned.
   </Step>
 </Steps>
 
@@ -102,7 +102,7 @@ The **aggregator node** is the coordination layer: it monitors onchain events, m
 
 ### Provision Nodes
 
-**Provision nodes** handle fiat execution: disbursing fiat to recipients for offramp orders, or receiving and confirming fiat deposits for onramp orders. They are run by independent liquidity providers who connect their own PSP integrations.
+**Provision nodes** handle fiat execution: disbursing fiat to recipients for off-ramp orders, or receiving and confirming fiat deposits for on-ramp orders. They are run by independent liquidity providers who connect their own PSP integrations.
 
 #### Components
 

--- a/concepts/compliance-security.mdx
+++ b/concepts/compliance-security.mdx
@@ -30,7 +30,7 @@ This model is how Paycrest achieves coverage in markets where a single centraliz
 
 ### For Senders
 
-Senders are companies or developers who integrate Paycrest to provide on- or offramp services to their users:
+Senders are companies or developers who integrate Paycrest to provide on- or off-ramp services to their users:
 
 - Business verification (KYB) required before API access is granted
 - Register at [app.paycrest.io](https://app.paycrest.io) and complete the KYB process

--- a/concepts/transaction-lifecycle.mdx
+++ b/concepts/transaction-lifecycle.mdx
@@ -123,7 +123,7 @@ The complete set of order status values:
 
 ## Webhook Events
 
-Paycrest sends webhooks to your configured endpoint as an order progresses. The event name format is `payment_order.<status>`. Failed deliveries are retried automatically with exponential backoff, and every delivery is queryable and replayable via the [sender webhook endpoints](/implementation-guides/sender-api-integration#webhook-delivery-logs--retry).
+Paycrest sends webhooks to your configured endpoint as an order progresses. Most events are named after the status the order just entered (`payment_order.<status>`); a small number report an event that is not a status change, and are marked below. Failed deliveries are retried automatically with exponential backoff, and every delivery is queryable and replayable via the [sender webhook endpoints](/implementation-guides/sender-api-integration#webhook-delivery-logs--retry).
 
 | Event | Triggered When |
 |-------|---------------|
@@ -135,9 +135,25 @@ Paycrest sends webhooks to your configured endpoint as an order progresses. The 
 | `payment_order.refunding` | Refund initiated |
 | `payment_order.refunded` | Refund complete |
 | `payment_order.expired` | Order expired after 5 minutes |
+| `payment_order.compliance_hold` | Onramp fiat received, settlement held pending compliance review (**not a status change** — see below) |
 
 <Note>
   Not all statuses emit webhooks. Intermediate states like `initiated`, `fulfilling`, and `cancelled` do not trigger webhook events.
+</Note>
+
+### Compliance holds
+
+`payment_order.compliance_hold` fires when an onramp order's fiat has been received but Paycrest cannot settle it while a compliance review is open. It is sent at most once per order.
+
+Two things make this event different from the rest:
+
+- **It is not a status change.** The order deliberately remains `pending`, so `data.status` reads `pending`, not `compliance_hold`. If you route webhooks by `data.status`, this event will look like a duplicate `pending` — branch on `event` instead.
+- **It is terminal in practice.** The order will not settle. It stays `pending` until its virtual account expires, at which point you also receive `payment_order.expired`. Do not prompt the customer to retry the payment — a second deposit into the same virtual account will be held as well.
+
+Treat it as a signal to stop expecting settlement and to contact Paycrest support about the affected order. What you tell your own customer is your decision.
+
+<Note>
+  Not every held order produces this event. Where a hold concerns your account rather than the counterparty, no webhook is sent and you will observe only `payment_order.expired`.
 </Note>
 
 ### Webhook Payload (v1)

--- a/concepts/transaction-lifecycle.mdx
+++ b/concepts/transaction-lifecycle.mdx
@@ -3,9 +3,9 @@ title: "Transaction Lifecycle"
 description: "Understanding how payment messages flow through the Paycrest protocol from order creation to settlement"
 ---
 
-Paycrest supports two payment directions: **offramp** (stablecoin → fiat) and **onramp** (fiat → stablecoin). Both flows follow a similar lifecycle through the protocol.
+Paycrest supports two payment directions: **off-ramp** (stablecoin → fiat) and **on-ramp** (fiat → stablecoin). Both flows follow a similar lifecycle through the protocol.
 
-## Offramp Lifecycle (Stablecoin → Fiat)
+## Off-ramp Lifecycle (Stablecoin → Fiat)
 
 ```mermaid
 stateDiagram-v2
@@ -55,10 +55,10 @@ stateDiagram-v2
 </Note>
 
 <Warning>
-  **expired vs refunded**: These are two distinct failure modes. `expired` means the receive address (offramp) or virtual account (onramp) was never funded — no deposit was received. `refunded` means a deposit was received but the order could not be fulfilled (e.g. no available provider, PSP unavailability, rate constraints) — and the deposited funds have been returned to the sender.
+  **expired vs refunded**: These are two distinct failure modes. `expired` means the receive address (off-ramp) or virtual account (on-ramp) was never funded — no deposit was received. `refunded` means a deposit was received but the order could not be fulfilled (e.g. no available provider, PSP unavailability, rate constraints) — and the deposited funds have been returned to the sender.
 </Warning>
 
-## Onramp Lifecycle (Fiat → Stablecoin)
+## On-ramp Lifecycle (Fiat → Stablecoin)
 
 ```mermaid
 stateDiagram-v2
@@ -79,7 +79,7 @@ stateDiagram-v2
 
 <Steps>
   <Step title="initiated">
-    Sender creates an onramp order via the API. The protocol returns provider account details (virtual bank account or mobile wallet) for the user to deposit fiat into.
+    Sender creates an on-ramp order via the API. The protocol returns provider account details (virtual bank account or mobile wallet) for the user to deposit fiat into.
   </Step>
   <Step title="pending">
     The aggregator has matched the order to a provider. Waiting for the user's fiat deposit to be confirmed by the provider.
@@ -109,7 +109,7 @@ The complete set of order status values:
 | Status | Description |
 |--------|-------------|
 | `initiated` | Order created, awaiting deposit |
-| `deposited` | Deposit confirmed (offramp only) |
+| `deposited` | Deposit confirmed (off-ramp only) |
 | `pending` | Assigned to provider, awaiting fulfillment |
 | `fulfilling` | Provider is disbursing fiat or stablecoins |
 | `fulfilled` | Fulfillment completed by provider (internal) |
@@ -135,7 +135,7 @@ Paycrest sends webhooks to your configured endpoint as an order progresses. Most
 | `payment_order.refunding` | Refund initiated |
 | `payment_order.refunded` | Refund complete |
 | `payment_order.expired` | Order expired after 5 minutes |
-| `payment_order.compliance_hold` | Onramp fiat received, settlement held pending compliance review (**not a status change** — see below) |
+| `payment_order.compliance_hold` | On-ramp fiat received, settlement held pending compliance review (**not a status change** — see below) |
 
 <Note>
   Not all statuses emit webhooks. Intermediate states like `initiated`, `fulfilling`, and `cancelled` do not trigger webhook events.
@@ -143,7 +143,7 @@ Paycrest sends webhooks to your configured endpoint as an order progresses. Most
 
 ### Compliance holds
 
-`payment_order.compliance_hold` fires when an onramp order's fiat has been received but Paycrest cannot settle it while a compliance review is open. It is sent at most once per order.
+`payment_order.compliance_hold` fires when an on-ramp order's fiat has been received but Paycrest cannot settle it while a compliance review is open. It is sent at most once per order.
 
 Two things make this event different from the rest:
 
@@ -195,7 +195,7 @@ Treat it as a signal to stop expecting settlement and to contact Paycrest suppor
 
 ### Webhook Payload (v2)
 
-The v2 payload adds a `direction` field and uses polymorphic `source`/`destination` objects that vary based on whether the order is an offramp or onramp:
+The v2 payload adds a `direction` field and uses polymorphic `source`/`destination` objects that vary based on whether the order is an off-ramp or on-ramp:
 
 ```json
 {
@@ -314,7 +314,7 @@ func verifyWebhook(payload []byte, signature, secret string) bool {
 
 There are two distinct failure paths:
 
-**`expired`** — No deposit was ever received. The receive address (offramp) or virtual account (onramp) expired without being funded. The order closes with no funds moved. Common causes:
+**`expired`** — No deposit was ever received. The receive address (off-ramp) or virtual account (on-ramp) expired without being funded. The order closes with no funds moved. Common causes:
 - User abandoned the payment flow
 - Deposit was sent to the wrong address or after the address expired
 

--- a/concepts/use-cases.mdx
+++ b/concepts/use-cases.mdx
@@ -56,9 +56,9 @@ const payoutOrder = await gateway.createOrder(
 - Faster settlement compared to traditional payment methods
 - Global reach for international creators
 
-### Crypto Exchange Offramp
+### Crypto Exchange Off-ramp
 
-**Overview:** Provide users with seamless offramp capabilities directly from crypto exchanges.
+**Overview:** Provide users with seamless off-ramp capabilities directly from crypto exchanges.
 
 **How it works:**
 - Exchange integrates Paycrest Sender API

--- a/implementation-guides/provider-setup-guide.mdx
+++ b/implementation-guides/provider-setup-guide.mdx
@@ -109,12 +109,12 @@ PAYAZA_TRANSACTION_PIN=
 - **How to generate it**: Create a new dedicated EVM wallet (do not reuse a personal wallet) and use that wallet's private key.
 - **Security**: Treat this as a production secret. Never commit it to git, store it in a secure secret manager or protected `.env`, and rotate it immediately if exposed.
 
-#### Starknet onramp envs explained
+#### Starknet on-ramp envs explained
 
 - **What they are**:
   - `STARKNET_SNIP9_USER_ADDRESS` — Starknet account address used to sign SNIP-9 OutsideExecution payin messages
   - `STARKNET_SNIP9_PRIVATE_KEY` — private key for that Starknet account
-- **When you need them**: Required when fulfilling **Starknet onramp (payin)** orders. If you only handle EVM/Tron or offramp-only flows, you can leave them unset.
+- **When you need them**: Required when fulfilling **Starknet on-ramp (payin)** orders. If you only handle EVM/Tron or offramp-only flows, you can leave them unset.
 - **Address format**: Use a Starknet felt hex address (`0x` + 63–64 hex characters), not an EVM checksum address.
 - **Security**: Treat both as production secrets. Never commit them to git, store them in a secure secret manager or protected `.env`, and rotate them immediately if exposed.
 

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Sender API Integration"
-description: "Ship offramp and onramp with one create call; add verify-account and public rates when you want a richer checkout UX."
+description: "Ship off-ramp and on-ramp with one create call; add verify-account and public rates when you want a richer checkout UX."
 ---
 
 The Sender API lets your app create payment orders in two directions:
 
-- **Offramp** — user sends stablecoins, recipient receives local fiat (bank or mobile wallet)
-- **Onramp** — user deposits fiat into a virtual account, recipient receives stablecoins
+- **Off-ramp** — user sends stablecoins, recipient receives local fiat (bank or mobile wallet)
+- **On-ramp** — user deposits fiat into a virtual account, recipient receives stablecoins
 
 Both flows use the same endpoint: **`POST /v2/sender/orders`**. Direction comes from the `source` and `destination` types you pass.
 
@@ -19,7 +19,7 @@ Prefer natural language? Create and track orders from **Claude Code**, **Cursor*
 ## Flow Overview
 
 <Tabs>
-  <Tab title="Offramp (Stablecoin → Fiat)">
+  <Tab title="Off-ramp (Stablecoin → Fiat)">
 ```mermaid
 sequenceDiagram
     participant App as Sender App
@@ -42,7 +42,7 @@ sequenceDiagram
     API-->>App: Webhook: payment_order.settled
 ```
   </Tab>
-  <Tab title="Onramp (Fiat → Stablecoin)">
+  <Tab title="On-ramp (Fiat → Stablecoin)">
 ```mermaid
 sequenceDiagram
     participant App as Sender App
@@ -82,7 +82,7 @@ const headers = {
 
 ### 2. Configure Tokens (Optional)
 
-In the dashboard settings, you can set defaults per token/network. **Offramp:** default `refundAddress` (crypto) and `feeAddress`; you can also pass `source.refundAddress` on the request. **Onramp:** you supply **`source.refundAccount`** (fiat bank or mobile details for refunds) in the order payload—configure related defaults in the dashboard where available.
+In the dashboard settings, you can set defaults per token/network. **Off-ramp:** default `refundAddress` (crypto) and `feeAddress`; you can also pass `source.refundAddress` on the request. **On-ramp:** you supply **`source.refundAccount`** (fiat bank or mobile details for refunds) in the order payload—configure related defaults in the dashboard where available.
 
 ---
 
@@ -90,14 +90,14 @@ In the dashboard settings, you can set defaults per token/network. **Offramp:** 
 
 **`POST /v2/sender/orders`**
 
-Pass a `source` and a `destination` object. The `type` field on each determines the direction. **Offramp** and **onramp** use the same endpoint; examples below include **`curl`** for both directions. The extra **JavaScript** and **Python** snippets are **offramp**-shaped—mirror the **onramp** `curl` payload (`source.type: "fiat"`, `destination.type: "crypto"`, `refundAccount`, etc.) in your language.
+Pass a `source` and a `destination` object. The `type` field on each determines the direction. **Off-ramp** and **on-ramp** use the same endpoint; examples below include **`curl`** for both directions. The extra **JavaScript** and **Python** snippets are **off-ramp**-shaped—mirror the **on-ramp** `curl` payload (`source.type: "fiat"`, `destination.type: "crypto"`, `refundAccount`, etc.) in your language.
 
 <Note>
-  **Starknet / Tron:** set `network` to **`starknet`** or **`tron`**. Crypto addresses (`source.refundAddress` on offramp, `destination.recipient.address` on onramp) must match the network: Starknet felt hex (`0x` + 63–64 hex digits) or Tron Base58 (`T…`). Do not pass EVM checksum addresses on these networks. See [Supported Stablecoins](/resources/supported-stablecoins).
+  **Starknet / Tron:** set `network` to **`starknet`** or **`tron`**. Crypto addresses (`source.refundAddress` on off-ramp, `destination.recipient.address` on on-ramp) must match the network: Starknet felt hex (`0x` + 63–64 hex digits) or Tron Base58 (`T…`). Do not pass EVM checksum addresses on these networks. See [Supported Stablecoins](/resources/supported-stablecoins).
 </Note>
 
 <Tabs>
-  <Tab title="Offramp (stablecoin → fiat)">
+  <Tab title="Off-ramp (stablecoin → fiat)">
 
 User sends stablecoins; recipient receives fiat. Set `source.type = "crypto"` and `destination.type = "fiat"`.
 
@@ -127,9 +127,9 @@ curl -X POST "https://api.paycrest.io/v2/sender/orders" \
   }'
 ```
   </Tab>
-  <Tab title="Offramp (Starknet)">
+  <Tab title="Off-ramp (Starknet)">
 
-Same shape as EVM offramp; use `network: "starknet"` and a Starknet refund address.
+Same shape as EVM off-ramp; use `network: "starknet"` and a Starknet refund address.
 
 ```bash
 curl -X POST "https://api.paycrest.io/v2/sender/orders" \
@@ -159,9 +159,9 @@ curl -X POST "https://api.paycrest.io/v2/sender/orders" \
 
 After create, transfer Starknet USDT/USDC to `providerAccount.receiveAddress` (also a Starknet address) before `validUntil`. Confirm settlement via webhooks or [GET order by ID](/api-reference/sender/get-payment-order-by-id-v2).
   </Tab>
-  <Tab title="Offramp (Tron)">
+  <Tab title="Off-ramp (Tron)">
 
-Same shape as EVM offramp; use `network: "tron"` and a Tron Base58 refund address (starts with `T`).
+Same shape as EVM off-ramp; use `network: "tron"` and a Tron Base58 refund address (starts with `T`).
 
 ```bash
 curl -X POST "https://api.paycrest.io/v2/sender/orders" \
@@ -191,7 +191,7 @@ curl -X POST "https://api.paycrest.io/v2/sender/orders" \
 
 After create, transfer Tron USDT to `providerAccount.receiveAddress` (also a Tron address) before `validUntil`. Confirm settlement via webhooks or [GET order by ID](/api-reference/sender/get-payment-order-by-id-v2).
   </Tab>
-  <Tab title="Onramp (fiat → stablecoin)">
+  <Tab title="On-ramp (fiat → stablecoin)">
 
 User deposits fiat; recipient receives stablecoins. Set `source.type = "fiat"` and `destination.type = "crypto"`.
 
@@ -224,7 +224,7 @@ curl -X POST "https://api.paycrest.io/v2/sender/orders" \
 ```
 
   </Tab>
-  <Tab title="JavaScript (offramp)">
+  <Tab title="JavaScript (off-ramp)">
 ```javascript
 const res = await fetch("https://api.paycrest.io/v2/sender/orders", {
   method: "POST",
@@ -253,7 +253,7 @@ const res = await fetch("https://api.paycrest.io/v2/sender/orders", {
 const order = await res.json();
 ```
   </Tab>
-  <Tab title="Python (offramp)">
+  <Tab title="Python (off-ramp)">
 ```python
 import requests
 
@@ -283,7 +283,7 @@ order = requests.post(
 ).json()
 ```
   </Tab>
-  <Tab title="JavaScript (onramp)">
+  <Tab title="JavaScript (on-ramp)">
 ```javascript
 const res = await fetch("https://api.paycrest.io/v2/sender/orders", {
   method: "POST",
@@ -314,7 +314,7 @@ const res = await fetch("https://api.paycrest.io/v2/sender/orders", {
 const order = await res.json();
 ```
   </Tab>
-  <Tab title="Python (onramp)">
+  <Tab title="Python (on-ramp)">
 ```python
 import requests
 
@@ -359,14 +359,14 @@ order = requests.post(
 | `senderFeePercent` | string | — | Optional fee percentage you collect, settled atomically onchain. Mutually exclusive with `senderFee`. |
 | `senderFeeAddress` | string | Conditionally | Fee recipient address. **Required when the effective sender fee is greater than zero** and no fee address is configured on the sender profile. Not required when fee is zero. |
 | `reference` | string | — | Your internal order ID. |
-| `source` | object | ✅ | `{ type: "crypto", ... }` for offramp; `{ type: "fiat", ... }` for onramp. |
-| `destination` | object | ✅ | `{ type: "fiat", ... }` for offramp; `{ type: "crypto", ... }` for onramp. |
+| `source` | object | ✅ | `{ type: "crypto", ... }` for off-ramp; `{ type: "fiat", ... }` for onramp. |
+| `destination` | object | ✅ | `{ type: "fiat", ... }` for off-ramp; `{ type: "crypto", ... }` for onramp. |
 
 ---
 
 ## KES mobile money (M-Pesa, Till, Paybill)
 
-Kenya offramp to mobile rails uses institution **`SAFAKEPC`** (Safaricom M-Pesa) or another KES **mobile_money** code from **[GET /institutions/KES](/api-reference/general/list-supported-institutions)**. **Till** and **Paybill** are not separate institution codes—you pass them in **`destination.recipient.metadata`**.
+Kenya off-ramp to mobile rails uses institution **`SAFAKEPC`** (Safaricom M-Pesa) or another KES **mobile_money** code from **[GET /institutions/KES](/api-reference/general/list-supported-institutions)**. **Till** and **Paybill** are not separate institution codes—you pass them in **`destination.recipient.metadata`**.
 
 | Channel | `metadata.channel` | `accountIdentifier` | Notes |
 |---------|-------------------|---------------------|--------|
@@ -409,9 +409,9 @@ Kenya offramp to mobile rails uses institution **`SAFAKEPC`** (Safaricom M-Pesa)
 }
 ```
 
-**KYC on offramp:** optional **`destination.kyc`** applies to the **recipient** only. Do not send sender or provider KYB on offramp create.
+**KYC on off-ramp:** optional **`destination.kyc`** applies to the **recipient** only. Do not send sender or provider KYB on off-ramp create.
 
-**GET / webhooks (v2):** for offramp orders, **`destination.recipient.metadata`** returns the metadata you supplied on create (same shape as above). **`destination.kyc`** returns destination KYC when stored. There is no v1-style flat metadata fallback on v2 GET.
+**GET / webhooks (v2):** for off-ramp orders, **`destination.recipient.metadata`** returns the metadata you supplied on create (same shape as above). **`destination.kyc`** returns destination KYC when stored. There is no v1-style flat metadata fallback on v2 GET.
 
 **Verify-account:** Till and Paybill identifiers are not normalized as mobile phone numbers. Use the exact till or paybill values you will send on the order.
 
@@ -419,9 +419,9 @@ Kenya offramp to mobile rails uses institution **`SAFAKEPC`** (Safaricom M-Pesa)
 
 ## Handle the create response
 
-The create response includes a `providerAccount` whose shape depends on direction: **offramp** gives a **crypto receive address**; **onramp** gives **virtual account / fiat transfer** instructions.
+The create response includes a `providerAccount` whose shape depends on direction: **off-ramp** gives a **crypto receive address**; **on-ramp** gives **virtual account / fiat transfer** instructions.
 
-### Offramp — send tokens to `receiveAddress`
+### Off-ramp — send tokens to `receiveAddress`
 
 ```json
 {
@@ -439,7 +439,7 @@ The create response includes a `providerAccount` whose shape depends on directio
 
 Send **exactly** `amount + senderFee + transactionFee` (all returned in the response) in the specified token to `providerAccount.receiveAddress` before `validUntil`.
 
-### Onramp — present virtual account to user
+### On-ramp — present virtual account to user
 
 ```json
 {
@@ -487,18 +487,18 @@ Configure your webhook URL in the [Sender Dashboard](https://app.paycrest.io). M
 
 | Event | When it fires |
 |-------|--------------|
-| `payment_order.deposited` | Stablecoin deposit detected (offramp) |
-| `payment_order.pending` | Assigned to provider / fiat deposit confirmed (onramp) |
+| `payment_order.deposited` | Stablecoin deposit detected (off-ramp) |
+| `payment_order.pending` | Assigned to provider / fiat deposit confirmed (on-ramp) |
 | `payment_order.validated` | Fiat payout confirmed by provider |
 | `payment_order.settling` | Onchain release in progress |
 | `payment_order.settled` | Order complete |
 | `payment_order.refunding` | Refund in progress |
 | `payment_order.refunded` | Funds returned to sender |
 | `payment_order.expired` | No deposit received before `validUntil` |
-| `payment_order.compliance_hold` | Onramp fiat received, settlement held pending compliance review. **Not a status change** — `data.status` stays `pending` |
+| `payment_order.compliance_hold` | On-ramp fiat received, settlement held pending compliance review. **Not a status change** — `data.status` stays `pending` |
 
 <Note>
-  You can notify the user of a successful offramp at `payment_order.validated` — that's when the provider has confirmed fiat delivery. For onramp, use `payment_order.settled` — that's when stablecoins are confirmed onchain.
+  You can notify the user of a successful off-ramp at `payment_order.validated` — that's when the provider has confirmed fiat delivery. For on-ramp, use `payment_order.settled` — that's when stablecoins are confirmed onchain.
 </Note>
 
 <Warning>
@@ -668,8 +668,8 @@ Use this when you want **clearer UX** before the user confirms—not because the
 
 **`POST /v2/verify-account`** runs the **same checks** again on create, but calling it first cuts down “invalid account” surprises and returns a canonical **`accountName`** for your form.
 
-- **Offramp** — verify the **fiat recipient** you will send in `destination.recipient` (same `institution` and `accountIdentifier` as the order).
-- **Onramp** — verify **`source.refundAccount`** (where fiat refunds go), not the crypto wallet in `destination.recipient`.
+- **Off-ramp** — verify the **fiat recipient** you will send in `destination.recipient` (same `institution` and `accountIdentifier` as the order).
+- **On-ramp** — verify **`source.refundAccount`** (where fiat refunds go), not the crypto wallet in `destination.recipient`.
 
 For **KES Till or Paybill**, pass the same **`accountIdentifier`** and **`metadata.channel`** you will use on create. Phone-style normalization does not apply to till or paybill numbers.
 
@@ -706,7 +706,7 @@ A `200 OK` response returns the resolved name in `data`. If `data` is a real nam
 **`GET /v2/rates/{network}/{from}/{amount}/{to}`** is **public** (no API key). **`from` and `to`** are the fiat code and token symbol in either order. Use it when you want to **show** a rate before submit, or when you will pass **`rate`** on create (it must stay within market tolerance). If you omit **`rate`** on create, the API still picks an acceptable rate.
 
 <Note>
-  The JSON `data` object includes **`buy`** and **`sell`** (unless you pass `?side=buy` or `?side=sell`). Use **`data.sell.rate`** for **offramp** and **`data.buy.rate`** for **onramp** when displaying a quote. **`provider_id`** is optional and must be exactly **8 letters** (`A–Z` or `a–z`) if you pin a provider.
+  The JSON `data` object includes **`buy`** and **`sell`** (unless you pass `?side=buy` or `?side=sell`). Use **`data.sell.rate`** for **off-ramp** and **`data.buy.rate`** for **on-ramp** when displaying a quote. **`provider_id`** is optional and must be exactly **8 letters** (`A–Z` or `a–z`) if you pin a provider.
 </Note>
 
 <Tabs>
@@ -810,7 +810,7 @@ Fixed fee alternative:
 }
 ```
 
-**Offramp:** the total stablecoin amount the user sends to `providerAccount.receiveAddress` is `amount + senderFee + transactionFee`, all returned in the create response. **Onramp:** the user pays **fiat** using `providerAccount.amountToTransfer` (and currency); fee line items in the response still describe what applies on settlement—follow the fields returned for your order.
+**Off-ramp:** the total stablecoin amount the user sends to `providerAccount.receiveAddress` is `amount + senderFee + transactionFee`, all returned in the create response. **On-ramp:** the user pays **fiat** using `providerAccount.amountToTransfer` (and currency); fee line items in the response still describe what applies on settlement—follow the fields returned for your order.
 
 ---
 
@@ -824,10 +824,10 @@ Paycrest runs on mainnet only. Test with the minimum order size: **$0.50 on any 
 
 ## v1 Legacy API
 
-The v1 API is fully supported for existing integrations. It supports **offramp only** and uses a flat request schema.
+The v1 API is fully supported for existing integrations. It supports **off-ramp only** and uses a flat request schema.
 
 <AccordionGroup>
-  <Accordion title="v1 Offramp — Create Order">
+  <Accordion title="v1 Off-ramp — Create Order">
 
 `POST /v1/sender/orders`
 
@@ -856,10 +856,10 @@ The response includes `receiveAddress` (string) and `validUntil`. Send tokens to
 
 | Feature | v1 | v2 |
 |---------|----|----|
-| Offramp | ✅ | ✅ |
-| Onramp | ❌ | ✅ |
+| Off-ramp | ✅ | ✅ |
+| On-ramp | ❌ | ✅ |
 | Schema | Flat: `token`, `network`, `recipient` | Polymorphic: `source`, `destination` with `type` |
-| `refundAddress` | `returnAddress` (top-level) | `source.refundAddress` (offramp); onramp uses `source.refundAccount` |
+| `refundAddress` | `returnAddress` (top-level) | `source.refundAddress` (off-ramp); on-ramp uses `source.refundAccount` |
 | Amount direction | Always crypto | `amountIn: "fiat"` or `"crypto"` |
 | Sender fee | Fixed via dashboard (fee + refund addresses required on profile) | Optional; `senderFee` / `senderFeePercent` on request. If fee > 0, `senderFeeAddress` (or profile fee address) is required |
 | Numeric types | Number | String |

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -468,7 +468,7 @@ Listen for webhooks or poll `GET /v2/sender/orders/:id`.
 
 ### Webhook Events
 
-Configure your webhook URL in the [Sender Dashboard](https://app.paycrest.io). Webhooks use the `payment_order.<status>` format and include a `direction` field (`"offramp"` or `"onramp"`):
+Configure your webhook URL in the [Sender Dashboard](https://app.paycrest.io). Most webhooks are named for the status the order entered (`payment_order.<status>`) and all include a `direction` field (`"offramp"` or `"onramp"`). Branch on `event` rather than `data.status` — a few events, noted below, are not status changes:
 
 ```json
 {
@@ -495,10 +495,15 @@ Configure your webhook URL in the [Sender Dashboard](https://app.paycrest.io). W
 | `payment_order.refunding` | Refund in progress |
 | `payment_order.refunded` | Funds returned to sender |
 | `payment_order.expired` | No deposit received before `validUntil` |
+| `payment_order.compliance_hold` | Onramp fiat received, settlement held pending compliance review. **Not a status change** — `data.status` stays `pending` |
 
 <Note>
   You can notify the user of a successful offramp at `payment_order.validated` — that's when the provider has confirmed fiat delivery. For onramp, use `payment_order.settled` — that's when stablecoins are confirmed onchain.
 </Note>
+
+<Warning>
+  **Do not prompt a retry on `payment_order.compliance_hold`.** The order will not settle and stays `pending` until its virtual account expires (you then also receive `payment_order.expired`). A second deposit into the same virtual account will be held too. Stop expecting settlement and contact support about the order — see [Compliance holds](/concepts/transaction-lifecycle#compliance-holds).
+</Warning>
 
 ### Verify Webhook Signatures
 

--- a/implementation-guides/sender-mcp.mdx
+++ b/implementation-guides/sender-mcp.mdx
@@ -299,7 +299,7 @@ Typical flow the agent should follow:
 
 <Steps>
   <Step title="Create">
-    Create an order (onramp or offramp) via natural language.
+    Create an order (on-ramp or off-ramp) via natural language.
   </Step>
   <Step title="Pay-in details">
     The agent shows pay-in details (bank / wallet / account info) and the order id.
@@ -319,13 +319,13 @@ You can also use the MCP prompt **“After payment — watch order”** and past
 
 ### Example prompts
 
-**Offramp** (crypto → fiat):
+**Off-ramp** (crypto → fiat):
 
 ```text
 offramp 0.5 USDC Base, refund 0x0c89b146E1dB0A1cf325e0bBA4FfFF24e3F1d0D4, NGN OPay 0987654321, John Doe.
 ```
 
-**Onramp** (fiat → crypto):
+**On-ramp** (fiat → crypto):
 
 ```text
 onramp 1000 NGN to USDC on Base at 0xCfb28A38b6083B2Ef0B4F99C7cC3aB76b71F0426, refund OPay 0987654321, name John Doe.

--- a/implementation-guides/smart-contract-interaction.mdx
+++ b/implementation-guides/smart-contract-interaction.mdx
@@ -3,7 +3,7 @@ title: "Smart Contract Interaction"
 description: "Integrate with Paycrest using the Gateway smart contract for onchain order management."
 ---
 
-Interact directly with the Paycrest Gateway smart contract for onchain <strong>stablecoin-to-fiat (offramp)</strong> order creation, settlement, and refunds. This approach gives you full control over the blockchain transactions and is ideal for dapps, wallets, or any EVM-compatible application.
+Interact directly with the Paycrest Gateway smart contract for onchain <strong>stablecoin-to-fiat (off-ramp)</strong> order creation, settlement, and refunds. This approach gives you full control over the blockchain transactions and is ideal for dapps, wallets, or any EVM-compatible application.
 
 <Note>
   This guide uses **Viem** for smart contract interactions, which is the recommended Ethereum library for modern applications. Viem provides better TypeScript support, improved performance, and a more intuitive API compared to ethers.js.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -35,7 +35,7 @@ Stablecoins have emerged as the most viable alternative: they move in minutes, c
 </Steps>
 
 <Note>
-  The entire flow completes in under 30 seconds for the majority of orders. The onramp flow inverts this: a user deposits fiat through a provider, and the protocol delivers stablecoins to their wallet.
+  The entire flow completes in under 30 seconds for the majority of orders. The on-ramp flow inverts this: a user deposits fiat through a provider, and the protocol delivers stablecoins to their wallet.
 </Note>
 
 ## What is Paycrest?
@@ -86,7 +86,7 @@ The key properties:
 
 <CardGroup cols={2}>
   <Card title="For Senders" href="/quickstart" icon="paper-plane">
-    Learn how to create payment orders and integrate with the Paycrest API. The Sender API v2 supports both offramp (stablecoin → fiat) and onramp (fiat → stablecoin).
+    Learn how to create payment orders and integrate with the Paycrest API. The Sender API v2 supports both off-ramp (stablecoin → fiat) and on-ramp (fiat → stablecoin).
   </Card>
   <Card title="For Providers" href="/implementation-guides/provider-setup-guide" icon="building">
     Set up a provision node to supply liquidity and earn fees
@@ -157,7 +157,7 @@ Paycrest is live across 4 active corridors with real provider liquidity. New cor
 
 ## Where We're Headed
 
-Paycrest is focused on one thing right now: making payment routing in emerging markets reliable enough to be trusted infrastructure. Q1 2026 delivered on that in the NGN corridor: sub-30 second completion for the majority of orders, a growing provider network with multiple independent PSPs, and onramp live in production.
+Paycrest is focused on one thing right now: making payment routing in emerging markets reliable enough to be trusted infrastructure. Q1 2026 delivered on that in the NGN corridor: sub-30 second completion for the majority of orders, a growing provider network with multiple independent PSPs, and on-ramp live in production.
 
 The next phase is hardening what works and replicating it across new corridors. LATAM comes first, starting with Argentina, and each corridor launches only when committed providers are onboarded and tested. Expansion is replication of a working model, not experimentation in production.
 

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1076,7 +1076,7 @@ components:
       properties:
         event:
           type: string
-          enum: [payment_order.deposited, payment_order.pending, payment_order.validated, payment_order.settling, payment_order.settled, payment_order.refunding, payment_order.refunded, payment_order.expired]
+          enum: [payment_order.deposited, payment_order.pending, payment_order.validated, payment_order.settling, payment_order.settled, payment_order.refunding, payment_order.refunded, payment_order.expired, payment_order.compliance_hold]
         webhookVersion:
           type: string
           enum: ["2"]
@@ -1147,7 +1147,7 @@ components:
           description: Unique ID of this delivery record.
         event:
           type: string
-          enum: [payment_order.deposited, payment_order.pending, payment_order.validated, payment_order.settling, payment_order.settled, payment_order.refunding, payment_order.refunded, payment_order.expired]
+          enum: [payment_order.deposited, payment_order.pending, payment_order.validated, payment_order.settling, payment_order.settled, payment_order.refunding, payment_order.refunded, payment_order.expired, payment_order.compliance_hold]
           description: The webhook event that was delivered.
         eventId:
           type: string

--- a/protocol-overview.mdx
+++ b/protocol-overview.mdx
@@ -142,20 +142,20 @@ A KYB-verified entity that coordinates the entire order routing process:
   <Step title="Fulfillment">
     Providers execute the payment:
     <ul>
-      <li><b>Offramp:</b> Provider delivers fiat to the recipient via PSP integration.</li>
-      <li><b>Onramp:</b> Provider receives fiat from the sender via local payment rails.</li>
+      <li><b>Off-ramp:</b> Provider delivers fiat to the recipient via PSP integration.</li>
+      <li><b>On-ramp:</b> Provider receives fiat from the sender via local payment rails.</li>
     </ul>
   </Step>
   <Step title="Validation">
     <ul>
-      <li><b>Offramp:</b> Provision node validates fulfillment by checking the status of the fiat transfer via PSP APIs.</li>
-      <li><b>Onramp:</b> Aggregator validates fulfillment by confirming the onchain stablecoin transfer to the recipient.</li>
+      <li><b>Off-ramp:</b> Provision node validates fulfillment by checking the status of the fiat transfer via PSP APIs.</li>
+      <li><b>On-ramp:</b> Aggregator validates fulfillment by confirming the onchain stablecoin transfer to the recipient.</li>
     </ul>
   </Step>
   <Step title="Settlement">
     <ul>
-      <li><b>Offramp:</b> Smart contract releases escrowed stablecoins to the provider after successful validation.</li>
-      <li><b>Onramp:</b> Fulfillment, validation, and settlement occur in one step: after the provision node confirms fiat receipt, the stablecoins are released onchain to the recipient.</li>
+      <li><b>Off-ramp:</b> Smart contract releases escrowed stablecoins to the provider after successful validation.</li>
+      <li><b>On-ramp:</b> Fulfillment, validation, and settlement occur in one step: after the provision node confirms fiat receipt, the stablecoins are released onchain to the recipient.</li>
     </ul>
   </Step>
   <Step title="Refund">
@@ -164,9 +164,9 @@ A KYB-verified entity that coordinates the entire order routing process:
 </Steps>
 
 <Callout type="info">
-<b>Offramp:</b> Fulfillment = Provider delivers fiat to recipient. Validation = Provision node checks fiat transfer status via PSP API. Settlement = Escrowed stablecoins released to provider.
+<b>Off-ramp:</b> Fulfillment = Provider delivers fiat to recipient. Validation = Provision node checks fiat transfer status via PSP API. Settlement = Escrowed stablecoins released to provider.
 
-<b>Onramp:</b> Fulfillment = Provider receives fiat from sender. Validation = Aggregator confirms onchain stablecoin transfer to recipient. Settlement = All three steps happen atomically after fiat receipt is confirmed.
+<b>On-ramp:</b> Fulfillment = Provider receives fiat from sender. Validation = Aggregator confirms onchain stablecoin transfer to recipient. Settlement = All three steps happen atomically after fiat receipt is confirmed.
 </Callout>
 
 ## Multi-Chain Support
@@ -283,7 +283,7 @@ If an order is not fulfilled, it is automatically refunded. The aggregator does 
 
 Senders can create orders via:
 - The Sender API (recommended for most users)
-- Direct contract interaction (for advanced/offramp use cases)
+- Direct contract interaction (for advanced/off-ramp use cases)
 
 <Note>
   The Paycrest protocol is designed to be both Web3-native and accessible to traditional financial applications. The modular architecture allows for different deployment models while maintaining the core benefits of decentralization.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Quickstart"
 description: "Create your first Paycrest payment order in minutes."
 ---
 
-This guide walks through creating a payment order using the Sender API, the recommended path for all new integrations. You'll have a working offramp in under 10 minutes. You do **not** need to call the public rates API first—`POST /v2/sender/orders` resolves an acceptable rate unless you pass a locked **`rate`** on create (see the [Sender API integration guide](/implementation-guides/sender-api-integration)).
+This guide walks through creating a payment order using the Sender API, the recommended path for all new integrations. You'll have a working off-ramp in under 10 minutes. You do **not** need to call the public rates API first—`POST /v2/sender/orders` resolves an acceptable rate unless you pass a locked **`rate`** on create (see the [Sender API integration guide](/implementation-guides/sender-api-integration)).
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ If you want to **show** an exchange rate in checkout before create, call the pub
 Use `POST /v2/sender/orders`. Set `source.type` and `destination.type` to choose the direction.
 
 <Tabs>
-  <Tab title="Offramp — stablecoin → fiat">
+  <Tab title="Off-ramp — stablecoin → fiat">
 ```bash
 curl -X POST "https://api.paycrest.io/v2/sender/orders" \
   -H "API-Key: YOUR_API_KEY" \
@@ -51,7 +51,7 @@ curl -X POST "https://api.paycrest.io/v2/sender/orders" \
   }'
 ```
   </Tab>
-  <Tab title="Onramp — fiat → stablecoin">
+  <Tab title="On-ramp — fiat → stablecoin">
 ```bash
 curl -X POST "https://api.paycrest.io/v2/sender/orders" \
   -H "API-Key: YOUR_API_KEY" \
@@ -256,7 +256,7 @@ fmt.Println(string(body))
   <Card title="Order Statuses" icon="list">
     <ul>
       <li><strong>initiated</strong> — order created, awaiting deposit</li>
-      <li><strong>deposited</strong> — deposit confirmed (offramp)</li>
+      <li><strong>deposited</strong> — deposit confirmed (off-ramp)</li>
       <li><strong>pending</strong> — assigned to provider</li>
       <li><strong>fulfilling</strong> — fiat/crypto disbursement in progress</li>
       <li><strong>validated</strong> — payout confirmed by provider</li>

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -18,7 +18,7 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 | Greater than zero (from `senderFee`, `senderFeePercent`, or a profile-configured fee) | **Required** — pass it on the request, or configure a fee address on the sender profile for that token |
 | Zero | **Not required** |
 
-`senderFee` and `senderFeePercent` remain mutually exclusive. Applies to both offramp and onramp. V1 create order is unchanged (still requires fee and refund addresses on the sender profile).
+`senderFee` and `senderFeePercent` remain mutually exclusive. Applies to both off-ramp and onramp. V1 create order is unchanged (still requires fee and refund addresses on the sender profile).
 
 See [Sender API Integration — Sender Fees](/implementation-guides/sender-api-integration#sender-fees) and [Initiate Order](/api-reference/sender/initiate-payment-order-v2).
 
@@ -110,13 +110,13 @@ See [Verify Account](/api-reference/general/verify-account).
 
 ---
 
-### KES Till and Paybill offramp (May 2026)
+### KES Till and Paybill off-ramp (May 2026)
 
-**Offramp** to Kenya mobile rails now supports **Till** (buy goods) and **Paybill** in addition to phone M-Pesa.
+**Off-ramp** to Kenya mobile rails now supports **Till** (buy goods) and **Paybill** in addition to phone M-Pesa.
 
 - On create, set **`destination.recipient.metadata.channel`** to **`Mobile`**, **`Till`**, or **`Paybill`** (use **`Mobile`** for phone M-Pesa; omit channel only when the identifier is a standard mobile number).
 - **Paybill** may require **`metadata.businessNumber`**.
-- Optional **`destination.kyc`** on offramp is **recipient-only** (no sender/provider KYB on create).
+- Optional **`destination.kyc`** on off-ramp is **recipient-only** (no sender/provider KYB on create).
 - **v2 GET / webhooks:** **`destination.recipient.metadata`** echoes create-time recipient metadata; **`destination.kyc`** when stored.
 - Till/Paybill identifiers are not normalized as phone numbers on create or verify-account.
 
@@ -153,9 +153,9 @@ See [Get Token Rate](/api-reference/general/get-token-rate) and [Get Market Rate
 
 ---
 
-### FX onramp settleIn principal alignment (April 2026)
+### FX on-ramp settleIn principal alignment (April 2026)
 
-No REST schema changes. For **FX onramp** pay-in, the aggregator now sizes onchain **`settleIn`** principal using Gateway fee settings (`providerToAggregatorFx`) so that, after the contract’s **floored** aggregator fee, the recipient still receives at least the **quoted net** crypto amount. Liquidity **reserve** and ERC-20 **approve** amounts align with that gross principal plus sender fee, and snapshots stored on the order keep release/cleanup consistent if chain settings move later.
+No REST schema changes. For **FX on-ramp** pay-in, the aggregator now sizes onchain **`settleIn`** principal using Gateway fee settings (`providerToAggregatorFx`) so that, after the contract’s **floored** aggregator fee, the recipient still receives at least the **quoted net** crypto amount. Liquidity **reserve** and ERC-20 **approve** amounts align with that gross principal plus sender fee, and snapshots stored on the order keep release/cleanup consistent if chain settings move later.
 
 Onchain principal amounts may differ slightly from older builds that used a looser ceiling gross-up; recipients should match the quoted net more precisely.
 
@@ -163,12 +163,12 @@ Onchain principal amounts may differ slightly from older builds that used a loos
 
 ## Q1 2026
 
-### v2 API — Onramp & Offramp (March 2026)
+### v2 API — On-ramp & Off-ramp (March 2026)
 
-The v2 API introduces a unified endpoint for both offramp and onramp flows, replacing the v1 offramp-only schema.
+The v2 API introduces a unified endpoint for both off-ramp and on-ramp flows, replacing the v1 offramp-only schema.
 
 **New endpoints:**
-- `POST /v2/sender/orders` — create offramp or onramp orders
+- `POST /v2/sender/orders` — create off-ramp or on-ramp orders
 - `GET /v2/sender/orders/:id` — get a single v2 order
 - `GET /v2/sender/orders` — list v2 orders
 - `GET /v2/provider/orders` — provider view of v2 orders
@@ -178,7 +178,7 @@ The v2 API introduces a unified endpoint for both offramp and onramp flows, repl
 
 | Feature | v1 | v2 |
 |---------|----|----|
-| Direction support | Offramp only | Offramp + onramp |
+| Direction support | Off-ramp only | Off-ramp + on-ramp |
 | Request schema | Flat: `token`, `network`, `recipient` | Polymorphic: `source`, `destination` with `type` discriminator |
 | Amount direction | Always crypto | `amountIn: "fiat"` or `"crypto"` |
 | Sender fee | Fixed amount via dashboard | Optional; `senderFee` / `senderFeePercent` on request. If fee > 0, `senderFeeAddress` (or profile fee address) is required |
@@ -191,18 +191,18 @@ The v1 API remains fully supported. No breaking changes to existing v1 integrati
 
 If you're building a new integration, use v2. Key differences to be aware of:
 
-1. The `source` and `destination` objects use a `type` discriminator (`"crypto"` or `"fiat"`) to distinguish offramp from onramp.
-2. For offramp, the `source.refundAddress` field replaces the v1 `returnAddress` field.
+1. The `source` and `destination` objects use a `type` discriminator (`"crypto"` or `"fiat"`) to distinguish off-ramp from onramp.
+2. For off-ramp, the `source.refundAddress` field replaces the v1 `returnAddress` field.
 3. All numeric values (amount, rate, fees) are returned as `string` in v2 — parse them as needed.
-4. The `providerAccount` in the create response is a virtual account (`V2FiatProviderAccount`) for onramp orders, replacing the `receiveAddress` string from v1.
+4. The `providerAccount` in the create response is a virtual account (`V2FiatProviderAccount`) for on-ramp orders, replacing the `receiveAddress` string from v1.
 
-See the [Sender API Integration Guide](/implementation-guides/sender-api-integration) for full v2 offramp and onramp documentation.
+See the [Sender API Integration Guide](/implementation-guides/sender-api-integration) for full v2 off-ramp and on-ramp documentation.
 
 ---
 
-### Onramp in production (March 2026)
+### On-ramp in production (March 2026)
 
-Fiat-to-stablecoin onramp is live across active corridors. Available via the v2 API.
+Fiat-to-stablecoin on-ramp is live across active corridors. Available via the v2 API.
 
 ---
 

--- a/resources/code-standards.mdx
+++ b/resources/code-standards.mdx
@@ -71,7 +71,7 @@ For KES **Till** and **Paybill** offramps, keep **`SAFAKEPC`** (or the same mobi
 
 ## API Usage
 
-When making API calls, always use the correct code format. For **new integrations**, use **[POST /v2/sender/orders](/api-reference/sender/initiate-payment-order-v2)** (offramp: stablecoin → fiat). Fiat currency is **`destination.currency`**; the bank or mobile-money institution is **`destination.recipient.institution`**. Crypto asset and chain are on **`source`** (`source.currency`, `source.network`).
+When making API calls, always use the correct code format. For **new integrations**, use **[POST /v2/sender/orders](/api-reference/sender/initiate-payment-order-v2)** (off-ramp: stablecoin → fiat). Fiat currency is **`destination.currency`**; the bank or mobile-money institution is **`destination.recipient.institution`**. Crypto asset and chain are on **`source`** (`source.currency`, `source.network`).
 
 ```javascript
 // v2 offramp — correct institution and currency codes (see OpenAPI for full required fields)

--- a/resources/supported-stablecoins.mdx
+++ b/resources/supported-stablecoins.mdx
@@ -92,7 +92,7 @@ const order = {
 };
 ```
   </Tab>
-  <Tab title="v2 Starknet offramp">
+  <Tab title="v2 Starknet off-ramp">
 ```javascript
 // Offramp: USDT on Starknet → NGN bank account
 // refundAddress must be a Starknet address (0x + 63–64 hex chars)
@@ -117,7 +117,7 @@ const order = {
 };
 ```
   </Tab>
-  <Tab title="v2 Tron offramp">
+  <Tab title="v2 Tron off-ramp">
 ```javascript
 // Offramp: USDT on Tron → NGN bank account
 // refundAddress must be a Tron Base58 address (starts with T)


### PR DESCRIPTION
## Summary

Documents the new **`payment_order.compliance_hold`** webhook event, shipped in https://github.com/paycrest/aggregator/pull/1042.

An onramp order whose fiat has arrived but which cannot settle while a compliance review is open now notifies the sender. It is the **first event that is not named after a status** — the order deliberately stays `pending`, so `data.status` reads `pending`, not `compliance_hold`. An integration routing on `data.status` would see it as a duplicate `pending`, so the docs now say plainly: branch on `event`.

## Changes

- **`concepts/transaction-lifecycle.mdx`** — table row plus a new **Compliance holds** section carrying the substance: not a status change, terminal in practice, don't prompt a retry, and a note that not every held order emits the event.
- **`implementation-guides/sender-api-integration.mdx`** — table row plus a `<Warning>`: a second deposit into the same virtual account is held too, so prompting a retry actively makes things worse for the customer.
- **`api-reference/introduction.mdx`** — event list entry.
- **`openapi-v2.yaml`** — added to both event enums (webhook payload + delivery record). Validated the file still parses.

Two places flatly claimed *"the event name format is `payment_order.<status>`"*. That became false the moment this event shipped and is exactly what would mislead an integrator, so both now say most events follow that form and point at the exceptions.

## Deliberate omission

The docs say some holds produce no webhook ("where a hold concerns your account rather than the counterparty") **without** explaining the underlying rule. Spelling out that a sender-profile match means *you* are the subject of the review would let a sender infer they are being reviewed from the absence of an event — which defeats the point of withholding it.

## Testing

`openapi-v2.yaml` parses cleanly (`yaml.safe_load`). Remaining check is a Mintlify preview build for the two new MDX blocks (`<Note>` / `<Warning>` render).